### PR TITLE
McSema bitcode stress test

### DIFF
--- a/rellic/AST/ExprCombine.cpp
+++ b/rellic/AST/ExprCombine.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// #define GOOGLE_STRIP_LOG 1
-
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 

--- a/rellic/AST/GenerateAST.cpp
+++ b/rellic/AST/GenerateAST.cpp
@@ -393,8 +393,3 @@ llvm::ModulePass *createGenerateASTPass(clang::ASTContext &ctx,
 }
 
 }  // namespace rellic
-
-// using namespace llvm;
-// using GenerateAST = rellic::GenerateAST;
-// INITIALIZE_PASS(GenerateAST, "generate_ast",
-//                 "Generate clang AST from LLVM IR", true, false)

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -471,7 +471,7 @@ void IRToASTVisitor::visitGetElementPtrInst(llvm::GetElementPtrInst &inst) {
                             /*is_arrow=*/false);
   };
 
-  for (auto &idx : inst.indices()) {
+  for (auto &idx : llvm::make_range(inst.idx_begin(), inst.idx_end())) {
     switch (indexed_type->getTypeID()) {
       // Initial pointer
       case llvm::Type::PointerTyID: {

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -779,4 +779,9 @@ void IRToASTVisitor::visitSelectInst(llvm::SelectInst &inst) {
   select = CreateConditionalOperatorExpr(ast_ctx, cond, tval, fval, type);
 }
 
+void IRToASTVisitor::visitPHINode(llvm::PHINode &inst) {
+  DLOG(INFO) << "visitPHINode: " << LLVMThingToString(&inst);
+  LOG(FATAL) << "Uninimplemented llvm::PHINode visitor!";
+}
+
 }  // namespace rellic

--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -35,7 +35,6 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   std::unordered_map<llvm::Value *, clang::ValueDecl *> value_decls;
   std::unordered_map<llvm::Value *, clang::Stmt *> stmts;
 
-  clang::FunctionDecl *GetFunctionDecl(llvm::Instruction *inst);
   clang::Expr *GetOperandExpr(llvm::Value *val);
   clang::QualType GetQualType(llvm::Type *type);
 

--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -61,8 +61,8 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   void visitReturnInst(llvm::ReturnInst &inst);
   void visitBinaryOperator(llvm::BinaryOperator &inst);
   void visitCmpInst(llvm::CmpInst &inst);
-  void visitPtrToInt(llvm::PtrToIntInst &inst);
-  void visitTruncInst(llvm::TruncInst &inst);
+  void visitCastInst(llvm::CastInst &inst);
+  void visitSelectInst(llvm::SelectInst &inst);
 };
 
 }  // namespace rellic

--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -43,7 +43,7 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   clang::VarDecl *CreateVarDecl(clang::DeclContext *decl_ctx, llvm::Type *type,
                                 std::string name);
 
-  clang::Expr *ImplicitCastOperand(clang::QualType dst, clang::Expr *op);
+  clang::Expr *CastOperand(clang::QualType dst, clang::Expr *op);
 
  public:
   IRToASTVisitor(clang::ASTContext &ctx);

--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -36,11 +36,10 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   std::unordered_map<llvm::Value *, clang::Stmt *> stmts;
 
   clang::FunctionDecl *GetFunctionDecl(llvm::Instruction *inst);
-  clang::Expr *GetOperandExpr(clang::DeclContext *decl_ctx, llvm::Value *val);
+  clang::Expr *GetOperandExpr(llvm::Value *val);
   clang::QualType GetQualType(llvm::Type *type);
 
-  clang::Expr *CreateLiteralExpr(clang::DeclContext *decl_ctx,
-                                 llvm::Constant *constant);
+  clang::Expr *CreateLiteralExpr(llvm::Constant *constant);
 
   clang::VarDecl *CreateVarDecl(clang::DeclContext *decl_ctx, llvm::Type *type,
                                 std::string name);
@@ -53,6 +52,7 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
 
   void VisitGlobalVar(llvm::GlobalVariable &var);
   void VisitFunctionDecl(llvm::Function &func);
+  void VisitArgument(llvm::Argument &arg);
 
   void visitCallInst(llvm::CallInst &inst);
   void visitGetElementPtrInst(llvm::GetElementPtrInst &inst);
@@ -62,6 +62,7 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   void visitReturnInst(llvm::ReturnInst &inst);
   void visitBinaryOperator(llvm::BinaryOperator &inst);
   void visitCmpInst(llvm::CmpInst &inst);
+  void visitPtrToInt(llvm::PtrToIntInst &inst);
 };
 
 }  // namespace rellic

--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -65,6 +65,7 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   void visitCmpInst(llvm::CmpInst &inst);
   void visitCastInst(llvm::CastInst &inst);
   void visitSelectInst(llvm::SelectInst &inst);
+  void visitPHINode(llvm::PHINode &inst);
 };
 
 }  // namespace rellic

--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -62,6 +62,7 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   void visitBinaryOperator(llvm::BinaryOperator &inst);
   void visitCmpInst(llvm::CmpInst &inst);
   void visitPtrToInt(llvm::PtrToIntInst &inst);
+  void visitTruncInst(llvm::TruncInst &inst);
 };
 
 }  // namespace rellic

--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -43,6 +43,8 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   clang::VarDecl *CreateVarDecl(clang::DeclContext *decl_ctx, llvm::Type *type,
                                 std::string name);
 
+  clang::Expr *ImplicitCastOperand(clang::QualType dst, clang::Expr *op);
+
  public:
   IRToASTVisitor(clang::ASTContext &ctx);
 

--- a/rellic/AST/Util.cpp
+++ b/rellic/AST/Util.cpp
@@ -178,9 +178,12 @@ clang::Expr *CreateStringLiteral(clang::ASTContext &ctx, std::string val,
 }
 
 clang::Expr *CreateInitListExpr(clang::ASTContext &ctx,
-                                std::vector<clang::Expr *> &exprs) {
-  return new (ctx) clang::InitListExpr(ctx, clang::SourceLocation(), exprs,
-                                       clang::SourceLocation());
+                                std::vector<clang::Expr *> &exprs,
+                                clang::QualType type) {
+  auto init = new (ctx) clang::InitListExpr(ctx, clang::SourceLocation(), exprs,
+                                            clang::SourceLocation());
+  init->setType(type);
+  return init;
 }
 
 clang::Expr *CreateArraySubscriptExpr(clang::ASTContext &ctx, clang::Expr *base,
@@ -225,6 +228,15 @@ clang::Expr *CreateImplicitCastExpr(clang::ASTContext &ctx,
                                     clang::Expr *op) {
   return clang::ImplicitCastExpr::Create(ctx, type, cast, op, nullptr,
                                          clang::VK_RValue);
+}
+
+clang::Expr *CreateConditionalOperatorExpr(clang::ASTContext &ctx,
+                                           clang::Expr *cond, clang::Expr *lhs,
+                                           clang::Expr *rhs,
+                                           clang::QualType type) {
+  return new (ctx) clang::ConditionalOperator(
+      cond, clang::SourceLocation(), lhs, clang::SourceLocation(), rhs, type,
+      clang::VK_RValue, clang::OK_Ordinary);
 }
 
 }  // namespace rellic

--- a/rellic/AST/Util.cpp
+++ b/rellic/AST/Util.cpp
@@ -170,6 +170,13 @@ clang::Expr *CreateTrueExpr(clang::ASTContext &ctx) {
   return CreateIntegerLiteral(ctx, val, type);
 }
 
+clang::Expr *CreateCharacterLiteral(clang::ASTContext &ctx, unsigned val,
+                                    clang::QualType type) {
+  return new (ctx) clang::CharacterLiteral(
+      val, clang::CharacterLiteral::CharacterKind::Ascii, type,
+      clang::SourceLocation());
+}
+
 clang::Expr *CreateStringLiteral(clang::ASTContext &ctx, std::string val,
                                  clang::QualType type) {
   return clang::StringLiteral::Create(

--- a/rellic/AST/Util.cpp
+++ b/rellic/AST/Util.cpp
@@ -213,7 +213,7 @@ clang::Expr *CreateNullPointerExpr(clang::ASTContext &ctx) {
   auto type = ctx.UnsignedIntTy;
   auto val = llvm::APInt::getNullValue(ctx.getTypeSize(type));
   auto zero = CreateIntegerLiteral(ctx, val, type);
-  return CreateCStyleCastExpr(ctx, ctx.getPointerType(ctx.VoidTy),
+  return CreateCStyleCastExpr(ctx, ctx.VoidPtrTy,
                               clang::CastKind::CK_NullToPointer, zero);
 }
 

--- a/rellic/AST/Util.cpp
+++ b/rellic/AST/Util.cpp
@@ -214,4 +214,17 @@ clang::Expr *CreateNullPointerExpr(clang::ASTContext &ctx) {
                               clang::CastKind::CK_NullToPointer, zero);
 }
 
+clang::Stmt *CreateDeclStmt(clang::ASTContext &ctx, clang::Decl *decl) {
+  return new (ctx)
+      clang::DeclStmt(clang::DeclGroupRef(decl), clang::SourceLocation(),
+                      clang::SourceLocation());
+}
+
+clang::Expr *CreateImplicitCastExpr(clang::ASTContext &ctx,
+                                    clang::QualType type, clang::CastKind cast,
+                                    clang::Expr *op) {
+  return clang::ImplicitCastExpr::Create(ctx, type, cast, op, nullptr,
+                                         clang::VK_RValue);
+}
+
 }  // namespace rellic

--- a/rellic/AST/Util.h
+++ b/rellic/AST/Util.h
@@ -90,6 +90,9 @@ clang::Expr *CreateIntegerLiteral(clang::ASTContext &ctx, llvm::APInt &val,
 
 clang::Expr *CreateTrueExpr(clang::ASTContext &ctx);
 
+clang::Expr *CreateCharacterLiteral(clang::ASTContext &ctx, unsigned val,
+                                    clang::QualType type);
+
 clang::Expr *CreateStringLiteral(clang::ASTContext &ctx, std::string val,
                                  clang::QualType);
 

--- a/rellic/AST/Util.h
+++ b/rellic/AST/Util.h
@@ -94,7 +94,8 @@ clang::Expr *CreateStringLiteral(clang::ASTContext &ctx, std::string val,
                                  clang::QualType);
 
 clang::Expr *CreateInitListExpr(clang::ASTContext &ctx,
-                                std::vector<clang::Expr *> &exprs);
+                                std::vector<clang::Expr *> &exprs,
+                                clang::QualType type);
 
 clang::Expr *CreateArraySubscriptExpr(clang::ASTContext &ctx, clang::Expr *base,
                                       clang::Expr *idx, clang::QualType type);
@@ -113,5 +114,10 @@ clang::Stmt *CreateDeclStmt(clang::ASTContext &ctx, clang::Decl *decl);
 clang::Expr *CreateImplicitCastExpr(clang::ASTContext &ctx,
                                     clang::QualType type, clang::CastKind cast,
                                     clang::Expr *op);
+
+clang::Expr *CreateConditionalOperatorExpr(clang::ASTContext &ctx,
+                                           clang::Expr *cond, clang::Expr *lhs,
+                                           clang::Expr *rhs,
+                                           clang::QualType type);
 
 }  // namespace rellic

--- a/rellic/AST/Util.h
+++ b/rellic/AST/Util.h
@@ -105,4 +105,13 @@ clang::Expr *CreateMemberExpr(clang::ASTContext &ctx, clang::Expr *base,
 
 clang::Expr *CreateNullPointerExpr(clang::ASTContext &ctx);
 
+clang::Expr *CreateCStyleCastExpr(clang::ASTContext &ctx, clang::QualType type,
+                                  clang::CastKind cast, clang::Expr *op);
+
+clang::Stmt *CreateDeclStmt(clang::ASTContext &ctx, clang::Decl *decl);
+
+clang::Expr *CreateImplicitCastExpr(clang::ASTContext &ctx,
+                                    clang::QualType type, clang::CastKind cast,
+                                    clang::Expr *op);
+
 }  // namespace rellic

--- a/rellic/AST/Z3ConvVisitor.cpp
+++ b/rellic/AST/Z3ConvVisitor.cpp
@@ -419,7 +419,7 @@ bool Z3ConvVisitor::VisitParenExpr(clang::ParenExpr *parens) {
     // Default to ignoring the parens, Z3 should know how
     // to interpret them.
     default:
-    break;
+      break;
   }
 
   InsertZ3Expr(parens, z3_expr);

--- a/rellic/AST/Z3ConvVisitor.h
+++ b/rellic/AST/Z3ConvVisitor.h
@@ -52,8 +52,6 @@ class Z3ConvVisitor : public clang::RecursiveASTVisitor<Z3ConvVisitor> {
 
   z3::sort GetZ3Sort(clang::QualType type);
 
-  // clang::QualType GetQualType(z3::sort z3_sort);
-
   clang::Expr *CreateLiteralExpr(z3::expr z3_expr);
   
   void VisitZ3Expr(z3::expr z3_expr);
@@ -78,6 +76,7 @@ class Z3ConvVisitor : public clang::RecursiveASTVisitor<Z3ConvVisitor> {
   bool VisitUnaryOperator(clang::UnaryOperator *c_op);
   bool VisitBinaryOperator(clang::BinaryOperator *c_op);
   bool VisitDeclRefExpr(clang::DeclRefExpr *c_ref);
+  bool VisitCharacterLiteral(clang::CharacterLiteral *c_lit);
   bool VisitIntegerLiteral(clang::IntegerLiteral *c_lit);
 
   bool VisitVarDecl(clang::VarDecl *var);

--- a/rellic/AST/Z3ConvVisitor.h
+++ b/rellic/AST/Z3ConvVisitor.h
@@ -37,6 +37,8 @@ class Z3ConvVisitor : public clang::RecursiveASTVisitor<Z3ConvVisitor> {
   z3::func_decl_vector z3_decl_vec;
   std::unordered_map<clang::ValueDecl *, unsigned> z3_decl_map;
   std::unordered_map<unsigned, clang::ValueDecl *> c_decl_map;
+  // Type map
+  std::unordered_map<unsigned, clang::TypeDecl *> c_type_decl_map;
 
   void InsertZ3Expr(clang::Expr *c_expr, z3::expr z3_expr);
   z3::expr GetZ3Expr(clang::Expr *c_expr);
@@ -47,9 +49,15 @@ class Z3ConvVisitor : public clang::RecursiveASTVisitor<Z3ConvVisitor> {
   void InsertZ3Decl(clang::ValueDecl *c_decl, z3::func_decl z3_decl);
   z3::func_decl GetZ3Decl(clang::ValueDecl *c_decl);
 
-  void InsertCDecl(z3::func_decl z3_decl, clang::ValueDecl *c_decl);
-  clang::ValueDecl *GetCDecl(z3::func_decl z3_decl);
+  void InsertCValDecl(z3::func_decl z3_decl, clang::ValueDecl *c_decl);
+  clang::ValueDecl *GetCValDecl(z3::func_decl z3_decl);
 
+  z3::sort GetZ3Sort(clang::QualType type);
+
+  clang::QualType GetQualType(z3::sort z3_sort);
+
+  clang::Expr *CreateLiteralExpr(z3::expr z3_expr);
+  
   void VisitZ3Expr(z3::expr z3_expr);
 
  public:
@@ -64,6 +72,7 @@ class Z3ConvVisitor : public clang::RecursiveASTVisitor<Z3ConvVisitor> {
   z3::expr Z3BoolCast(z3::expr expr);
 
   bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr *sub);
+  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *cast);
   bool VisitCStyleCastExpr(clang::CStyleCastExpr *cast);
   bool VisitMemberExpr(clang::MemberExpr *expr);
   bool VisitCallExpr(clang::CallExpr *call);

--- a/rellic/AST/Z3ConvVisitor.h
+++ b/rellic/AST/Z3ConvVisitor.h
@@ -52,7 +52,7 @@ class Z3ConvVisitor : public clang::RecursiveASTVisitor<Z3ConvVisitor> {
 
   z3::sort GetZ3Sort(clang::QualType type);
 
-  clang::QualType GetQualType(z3::sort z3_sort);
+  // clang::QualType GetQualType(z3::sort z3_sort);
 
   clang::Expr *CreateLiteralExpr(z3::expr z3_expr);
   

--- a/rellic/AST/Z3ConvVisitor.h
+++ b/rellic/AST/Z3ConvVisitor.h
@@ -37,8 +37,6 @@ class Z3ConvVisitor : public clang::RecursiveASTVisitor<Z3ConvVisitor> {
   z3::func_decl_vector z3_decl_vec;
   std::unordered_map<clang::ValueDecl *, unsigned> z3_decl_map;
   std::unordered_map<unsigned, clang::ValueDecl *> c_decl_map;
-  // Type map
-  std::unordered_map<unsigned, clang::TypeDecl *> c_type_decl_map;
 
   void InsertZ3Expr(clang::Expr *c_expr, z3::expr z3_expr);
   z3::expr GetZ3Expr(clang::Expr *c_expr);

--- a/tests/array_swap.c
+++ b/tests/array_swap.c
@@ -1,0 +1,8 @@
+int a[2] = {0, 42};
+
+int main(void) {
+  int b = a[0];
+  a[0] = a[1];
+  a[1] = b;  
+  return a[0];
+}

--- a/tests/bitops.c
+++ b/tests/bitops.c
@@ -1,0 +1,6 @@
+int a = 0xFF;
+
+int main(void) {
+    a = (unsigned int)a >> 7;
+    return a ^ 1;
+}

--- a/tests/cast.c
+++ b/tests/cast.c
@@ -1,0 +1,4 @@
+int a = 0;
+int main(void) {
+    return (long long) &a;
+}

--- a/tests/funcptr.c
+++ b/tests/funcptr.c
@@ -1,0 +1,15 @@
+int add(int a, int b) { return a + b; }
+
+int sub(int a, int b) { return a - b; }
+
+int x = 0;
+
+int main(void) {
+  int (*func)(int, int);
+  if (x) {
+    func = add;
+  } else {
+    func = sub;
+  }
+  return func(2, 2);
+}

--- a/tests/init_list.c
+++ b/tests/init_list.c
@@ -1,5 +1,3 @@
-unsigned a[5] = {0,1,2,3,4};
+unsigned a[5] = {0, 1, 2, 3, 4};
 
-int main(void) {
-    return 0;
-}
+int main(void) { return a[1]; }

--- a/tests/inttoptr.c
+++ b/tests/inttoptr.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+unsigned long a = 0xDEADBEEF;
+int main(void) {
+    int *b = (int *)a;
+    if (b != NULL) {
+        return 42;
+    } else {
+        return 0;
+    }
+}

--- a/tests/nested_struct.c
+++ b/tests/nested_struct.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+
+struct _pair {
+  int first;
+  int second;
+};
+
+struct _person {
+  const char *name;
+  char age;
+};
+
+struct _record {
+  int a;
+  struct _pair b;
+  struct _person c;
+};
+
+struct _record r1 = {14, {33, 42}, {"Bob", 66}};
+
+int main(void) {
+  printf("Name: %s", r1.c.name);
+  return r1.b.second;
+}

--- a/tests/nullptr.c
+++ b/tests/nullptr.c
@@ -1,0 +1,9 @@
+int *ptr = ((void*)0);
+
+int main(void) {
+  if (ptr == ((void*)0)) {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/tests/ret0.c
+++ b/tests/ret0.c
@@ -1,0 +1,6 @@
+int f(void) {
+    return 1;
+}
+int main(void) {
+    return f();
+}

--- a/tests/struct.c
+++ b/tests/struct.c
@@ -1,0 +1,14 @@
+struct _pair {
+  int first;
+  int second;
+};
+
+struct _pair a = {0, 42};
+
+int main(void) {
+  if (a.first) {
+    return a.first;
+  } else {
+    return a.second;
+  }
+}

--- a/tests/struct_swap.c
+++ b/tests/struct_swap.c
@@ -1,0 +1,13 @@
+struct _pair {
+  int first;
+  int second;
+};
+
+struct _pair a = {0, 42};
+
+int main(void) {
+  int b = a.first;
+  a.first = a.second;
+  a.second = b;  
+  return a.first;
+}

--- a/tests/trunc.c
+++ b/tests/trunc.c
@@ -1,0 +1,4 @@
+unsigned long long a = -1;
+int main(void) {
+    return a;
+}

--- a/tests/zeroinit.c
+++ b/tests/zeroinit.c
@@ -1,0 +1,30 @@
+#include <string.h>
+
+struct _pair {
+  int first;
+  int second;
+};
+
+struct _person {
+  const char *name;
+  char age;
+};
+
+struct _record {
+  int a;
+  struct _pair b;
+  struct _person c;
+};
+
+struct _record r1 = {};
+long long a1[256] = {};
+
+int main(void) {
+  if (r1.b.first != 0)
+    return 1;
+
+  if (a1[42] != 0)
+    return 2;
+
+  return 0;
+}

--- a/tests/zext.c
+++ b/tests/zext.c
@@ -1,0 +1,4 @@
+unsigned char a = 1;
+int main(void) {
+    return (unsigned int)a;
+}

--- a/tools/decomp/Decomp.cpp
+++ b/tools/decomp/Decomp.cpp
@@ -26,13 +26,13 @@
 #include <clang/Basic/TargetInfo.h>
 
 #include "rellic/AST/CondBasedRefine.h"
+#include "rellic/AST/DeadStmtElim.h"
+#include "rellic/AST/ExprCombine.h"
 #include "rellic/AST/GenerateAST.h"
 #include "rellic/AST/IRToASTVisitor.h"
 #include "rellic/AST/LoopRefine.h"
 #include "rellic/AST/NestedCondProp.h"
 #include "rellic/AST/NestedScopeCombiner.h"
-#include "rellic/AST/ExprCombine.h"
-#include "rellic/AST/DeadStmtElim.h"
 #include "rellic/AST/Z3CondSimplify.h"
 
 #include "rellic/BC/Util.h"
@@ -91,6 +91,8 @@ static bool GeneratePseudocode(llvm::Module& module,
   cbr.add(rellic::createNestedCondPropPass(ast_ctx, gen));
   cbr.add(rellic::createNestedScopeCombinerPass(ast_ctx, gen));
   cbr.add(rellic::createCondBasedRefinePass(ast_ctx, gen));
+  // cbr.run(module);
+  // cbr.run(module);
   while (cbr.run(module))
     ;
 

--- a/tools/decomp/Decomp.cpp
+++ b/tools/decomp/Decomp.cpp
@@ -91,8 +91,6 @@ static bool GeneratePseudocode(llvm::Module& module,
   cbr.add(rellic::createNestedCondPropPass(ast_ctx, gen));
   cbr.add(rellic::createNestedScopeCombinerPass(ast_ctx, gen));
   cbr.add(rellic::createCondBasedRefinePass(ast_ctx, gen));
-  // cbr.run(module);
-  // cbr.run(module);
   while (cbr.run(module))
     ;
 


### PR DESCRIPTION
Adds various instruction handlers to both `IR->AST` and `Z3 <-> C` conversion passes, fixes issues with old code that bubbled up along the way, does some minor refactors. End result is that bitcode produced from [McSema](https://github.com/lifting-bits/mcsema) produces C.

Now to set expectations right, the C has syntax errors and is unlikely to work even when those are fixed. The purpose of passing McSema bitcode was to stress test rellic. Not to produce working C from it. Maybe sometime in the future rellic will be able to produce re-compilable bitcode from McSema.

resolves #34 