### PR TITLE
Add more missing BinOp

### DIFF
--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -670,6 +670,10 @@ void IRToASTVisitor::visitBinaryOperator(llvm::BinaryOperator &inst) {
       binop = BinOpExpr(clang::BO_Rem, lhs->getType());
       break;
 
+    case llvm::BinaryOperator::SRem:
+      binop = BinOpExpr(clang::BO_Rem, lhs->getType());
+      break;
+
     case llvm::BinaryOperator::Add:
       binop = BinOpExpr(clang::BO_Add, type);
       break;
@@ -683,7 +687,7 @@ void IRToASTVisitor::visitBinaryOperator(llvm::BinaryOperator &inst) {
       break;
 
     default:
-      LOG(FATAL) << "Unknown BinaryOperator: " << llvm::Instruction::getOpcodeName(inst.getOpcode());
+      LOG(FATAL) << "Unknown BinaryOperator: " << inst.getOpcodeName();
       break;
   }
 }

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -658,6 +658,10 @@ void IRToASTVisitor::visitBinaryOperator(llvm::BinaryOperator &inst) {
       binop = BinOpExpr(clang::BO_And, type);
       break;
 
+    case llvm::BinaryOperator::Or:
+      binop = BinOpExpr(clang::BO_Or, type);
+      break;
+
     case llvm::BinaryOperator::Xor:
       binop = BinOpExpr(clang::BO_Xor, type);
       break;
@@ -674,8 +678,12 @@ void IRToASTVisitor::visitBinaryOperator(llvm::BinaryOperator &inst) {
       binop = BinOpExpr(clang::BO_Sub, type);
       break;
 
+    case llvm::BinaryOperator::Mul:
+      binop = BinOpExpr(clang::BO_Mul, type);
+      break;
+
     default:
-      LOG(FATAL) << "Unknown BinaryOperator operation";
+      LOG(FATAL) << "Unknown BinaryOperator: " << llvm::Instruction::getOpcodeName(inst.getOpcode());
       break;
   }
 }

--- a/tests/tools/decomp/binops.c
+++ b/tests/tools/decomp/binops.c
@@ -1,0 +1,21 @@
+__attribute__ ((used))
+unsigned int target(unsigned int n) {
+  unsigned int mod = n % 4;
+  unsigned int result = 0;
+
+  if (mod == 0) {
+    result = (n | 0xbaaad0bf) * (2 ^ n);
+  } else if (mod == 1) {
+    result = (n & 0xbaaad0bf) * (3 + n);
+  } else if (mod == 2) {
+    result = (n ^ 0xbaaad0bf) * (4 | n);
+  } else {
+    result = (n + 0xbaaad0bf) * (5 & n);
+  }
+
+  return result;
+}
+
+int main(void) {
+    return 0;
+}


### PR DESCRIPTION
- `Or` and `Mul` opcodes
- Added print so the missing opcode is known in the error

Note that division is still missing, I am not certain on how to handle both unsigned or signed division (or does it even matter, I may just lift it as the `clang::BO_Div`?)