### PR TITLE
Add unzip Ubuntu build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ sudo apt-get install \
      git \
      python2.7 \
      wget \
+     unzip \
      curl \
      build-essential \
      libtinfo-dev \

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -52,7 +52,7 @@ linux_initialize() {
   fi
 
   printf " > Installing the required packages...\n"
-  sudo apt-get install -qqy git python2.7 curl realpath build-essential gcc-multilib g++-multilib libomp-dev libtinfo-dev lsb-release
+  sudo apt-get install -qqy git python2.7 unzip curl realpath build-essential gcc-multilib g++-multilib libomp-dev libtinfo-dev lsb-release
   if [ $? -ne 0 ] ; then
     printf " x Could not install the required dependencies\n"
     return 1


### PR DESCRIPTION
`unzip` is used when extracting the downloaded Z3 package.

I found this by trying to create a Docker image and found that the unzip
command was missing.

I also added it to the `scripts/travis.sh` script, in case the script was ever used in a CI environment that didn't have unzip preinstalled.