### PR TITLE
Adds elim-and before tseitin-cnf to get rid of leftover aux vars

### DIFF
--- a/rellic/AST/Z3ConvVisitor.cpp
+++ b/rellic/AST/Z3ConvVisitor.cpp
@@ -132,14 +132,15 @@ z3::expr Z3ConvVisitor::Z3BoolCast(z3::expr expr) {
 void Z3ConvVisitor::InsertCExpr(z3::expr z_expr, clang::Expr *c_expr) {
   auto hash = z_expr.hash();
   auto iter = c_expr_map.find(hash);
-  CHECK(iter == c_expr_map.end());
+  CHECK(iter == c_expr_map.end())
+      << "Z3 equivalent for C declaration already exists!";
   c_expr_map[hash] = c_expr;
 }
 
 clang::Expr *Z3ConvVisitor::GetCExpr(z3::expr z_expr) {
   auto hash = z_expr.hash();
   auto iter = c_expr_map.find(hash);
-  CHECK(iter != c_expr_map.end());
+  CHECK(iter != c_expr_map.end()) << "No Z3 equivalent for C declaration!";
   return c_expr_map[hash];
 }
 
@@ -147,14 +148,15 @@ void Z3ConvVisitor::InsertCValDecl(z3::func_decl z_decl,
                                    clang::ValueDecl *c_decl) {
   auto id = Z3_get_func_decl_id(*z3_ctx, z_decl);
   auto iter = c_decl_map.find(id);
-  CHECK(iter == c_decl_map.end());
+  CHECK(iter == c_decl_map.end())
+      << "C equivalent for Z3 declaration already exists!";
   c_decl_map[id] = c_decl;
 }
 
 clang::ValueDecl *Z3ConvVisitor::GetCValDecl(z3::func_decl z_decl) {
   auto id = Z3_get_func_decl_id(*z3_ctx, z_decl);
   auto iter = c_decl_map.find(id);
-  CHECK(iter != c_decl_map.end());
+  CHECK(iter != c_decl_map.end()) << "No C equivalent for Z3 declaration!";
   return c_decl_map[id];
 }
 

--- a/tools/decomp/Decomp.cpp
+++ b/tools/decomp/Decomp.cpp
@@ -107,6 +107,8 @@ static bool GeneratePseudocode(llvm::Module& module,
       z3::tactic(fin_simplifier->GetZ3Context(), "aig") &
       // Propagate bounds over bit-vectors
       z3::tactic(fin_simplifier->GetZ3Context(), "propagate-bv-bounds") &
+      // Eliminate conjunctions using De Morgan laws
+      z3::tactic(fin_simplifier->GetZ3Context(), "elim-and") &
       // Tseitin transformation
       z3::tactic(fin_simplifier->GetZ3Context(), "tseitin-cnf") &
       // Contextual simplification


### PR DESCRIPTION
closes #50 and adds a few nicer errors.