### PR TITLE
Adds reachability-based refinement from No More Gotos

### DIFF
--- a/rellic/AST/CondBasedRefine.cpp
+++ b/rellic/AST/CondBasedRefine.cpp
@@ -18,6 +18,7 @@
 #include <glog/logging.h>
 
 #include "rellic/AST/CondBasedRefine.h"
+#include "rellic/AST/Util.h"
 
 namespace rellic {
 

--- a/rellic/AST/CondBasedRefine.h
+++ b/rellic/AST/CondBasedRefine.h
@@ -18,11 +18,8 @@
 
 #include <llvm/IR/Module.h>
 
-#include <set>
-
 #include "rellic/AST/IRToASTVisitor.h"
 #include "rellic/AST/TransformVisitor.h"
-#include "rellic/AST/Util.h"
 #include "rellic/AST/Z3ConvVisitor.h"
 
 namespace rellic {

--- a/rellic/AST/CondBasedRefine.h
+++ b/rellic/AST/CondBasedRefine.h
@@ -34,11 +34,12 @@ class CondBasedRefine : public llvm::ModulePass,
   rellic::IRToASTVisitor *ast_gen;
   std::unique_ptr<z3::context> z3_ctx;
   std::unique_ptr<rellic::Z3ConvVisitor> z3_gen;
+  
+  z3::tactic z3_solver;
 
   z3::expr GetZ3Cond(clang::IfStmt *ifstmt);
 
-  bool ThenTest(z3::expr lhs, z3::expr rhs);
-  bool ElseTest(z3::expr lhs, z3::expr rhs);
+  bool Prove(z3::expr expr);
 
   using IfStmtVec = std::vector<clang::IfStmt *>;
 

--- a/rellic/AST/NestedCondProp.cpp
+++ b/rellic/AST/NestedCondProp.cpp
@@ -68,8 +68,11 @@ bool NestedCondProp::VisitIfStmt(clang::IfStmt *ifstmt) {
         for (auto child : GetIfStmts(comp)) {
           parent_conds[child] = CreateNotExpr(*ast_ctx, cond);
         }
+      } else if (auto elif = clang::dyn_cast<clang::IfStmt>(stmt_else)) {
+        parent_conds[elif] = CreateNotExpr(*ast_ctx, cond);
       } else {
-        LOG(FATAL) << "Else branch must be a clang::CompoundStmt!";
+        LOG(FATAL)
+            << "Else branch must be a clang::CompoundStmt or clang::IfStmt!";
       }
     }
   }

--- a/rellic/AST/ReachBasedRefine.cpp
+++ b/rellic/AST/ReachBasedRefine.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2020 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include "rellic/AST/ReachBasedRefine.h"
+
+namespace rellic {
+
+namespace {
+
+using IfStmtVec = std::vector<clang::IfStmt *>;
+
+static IfStmtVec GetIfStmts(clang::CompoundStmt *compound) {
+  IfStmtVec result;
+  for (auto stmt : compound->body()) {
+    if (auto ifstmt = clang::dyn_cast<clang::IfStmt>(stmt)) {
+      result.push_back(ifstmt);
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+char ReachBasedRefine::ID = 0;
+
+ReachBasedRefine::ReachBasedRefine(clang::ASTContext &ctx,
+                                   rellic::IRToASTVisitor &ast_gen)
+    : ModulePass(ReachBasedRefine::ID),
+      ast_ctx(&ctx),
+      ast_gen(&ast_gen),
+      z3_ctx(new z3::context()),
+      z3_gen(new rellic::Z3ConvVisitor(ast_ctx, z3_ctx.get())),
+      z3_solver(*z3_ctx, "sat") {}
+
+bool ReachBasedRefine::Prove(z3::expr expr) {
+  z3::goal goal(*z3_ctx);
+  goal.add((!expr).simplify());
+  auto app = z3_solver(goal);
+  CHECK(app.size() == 1) << "Unexpected multiple goals in application!";
+  return app[0].is_decided_unsat();
+}
+
+z3::expr ReachBasedRefine::GetZ3Cond(clang::IfStmt *ifstmt) {
+  auto cond = ifstmt->getCond();
+  auto expr = z3_gen->Z3BoolCast(z3_gen->GetOrCreateZ3Expr(cond));
+  return expr.simplify();
+}
+
+void ReachBasedRefine::CreateIfElseStmts(IfStmtVec stmts) {
+  IfStmtVec elifs;
+  z3::expr_vector conds(*z3_ctx);
+
+  auto IsUnrechable = [this, &conds](z3::expr cond) {
+    return !Prove(cond && z3::mk_or(conds));
+  };
+
+  auto IsTautology = [this, &conds] {
+    return Prove(z3::mk_or(conds) == z3_ctx->bool_val(true));
+  };
+
+  for (auto stmt : llvm::make_range(stmts.rbegin(), stmts.rend())) {
+    if (IsTautology()) {
+      break;
+    }
+    auto cond = GetZ3Cond(stmt);
+    if (!stmt->getElse() && IsUnrechable(cond)) {
+      conds.push_back(cond);
+      elifs.push_back(stmt);
+    }
+  }
+
+  if (elifs.size() < 2) {
+    return;
+  }
+
+  clang::IfStmt *sub = nullptr;
+  for (auto stmt : llvm::make_range(elifs.rbegin(), elifs.rend())) {
+    auto cond = stmt->getCond();
+    auto then = stmt->getThen();
+    if (stmt == elifs.back()) {
+      sub = CreateIfStmt(*ast_ctx, cond, then);
+      substitutions[stmt] = sub;
+    } else if (stmt == elifs.front()) {
+      std::vector<clang::Stmt *> thens({then});
+      sub->setElse(CreateCompoundStmt(*ast_ctx, thens));
+    } else {
+      auto elif = CreateIfStmt(*ast_ctx, cond, then);
+      sub->setElse(elif);
+      sub = elif;
+    }
+  }
+
+  elifs.pop_back();
+
+  for (auto stmt : elifs) {
+    substitutions[stmt] = nullptr;
+  }
+}
+
+bool ReachBasedRefine::VisitCompoundStmt(clang::CompoundStmt *compound) {
+  // DLOG(INFO) << "VisitCompoundStmt";
+  // Create if-else cascade substitutions for IfStmts in `compound`
+  CreateIfElseStmts(GetIfStmts(compound));
+  // Apply created if-else substitutions and
+  // create a replacement for `compound`
+  if (ReplaceChildren(compound, substitutions)) {
+    std::vector<clang::Stmt *> new_body;
+    for (auto stmt : compound->body()) {
+      if (stmt) {
+        new_body.push_back(stmt);
+      }
+    }
+    substitutions[compound] = CreateCompoundStmt(*ast_ctx, new_body);
+  }
+  return true;
+}
+
+bool ReachBasedRefine::runOnModule(llvm::Module &module) {
+  LOG(INFO) << "Reachability-based refinement";
+  Initialize();
+  TraverseDecl(ast_ctx->getTranslationUnitDecl());
+  return changed;
+}
+
+llvm::ModulePass *createReachBasedRefinePass(clang::ASTContext &ctx,
+                                             rellic::IRToASTVisitor &gen) {
+  return new ReachBasedRefine(ctx, gen);
+}
+
+}  // namespace rellic

--- a/rellic/AST/ReachBasedRefine.h
+++ b/rellic/AST/ReachBasedRefine.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <llvm/IR/Module.h>
+
+#include "rellic/AST/IRToASTVisitor.h"
+#include "rellic/AST/TransformVisitor.h"
+#include "rellic/AST/Util.h"
+#include "rellic/AST/Z3ConvVisitor.h"
+
+namespace rellic {
+
+class ReachBasedRefine : public llvm::ModulePass,
+                         public TransformVisitor<ReachBasedRefine> {
+ private:
+  clang::ASTContext *ast_ctx;
+  rellic::IRToASTVisitor *ast_gen;
+  std::unique_ptr<z3::context> z3_ctx;
+  std::unique_ptr<rellic::Z3ConvVisitor> z3_gen;
+
+  z3::tactic z3_solver;
+
+  z3::expr GetZ3Cond(clang::IfStmt *ifstmt);
+  
+  bool Prove(z3::expr expr);
+
+  using IfStmtVec = std::vector<clang::IfStmt *>;
+  
+  void CreateIfElseStmts(IfStmtVec stmts);
+ 
+ public:
+  static char ID;
+
+  ReachBasedRefine(clang::ASTContext &ctx, rellic::IRToASTVisitor &ast_gen);
+
+  bool VisitCompoundStmt(clang::CompoundStmt *compound);
+
+  bool runOnModule(llvm::Module &module) override;
+};
+
+llvm::ModulePass *createReachBasedRefinePass(clang::ASTContext &ctx,
+                                             rellic::IRToASTVisitor &ast_gen);
+}  // namespace rellic
+
+namespace llvm {
+void initializeReachBasedRefinePass(PassRegistry &);
+}

--- a/rellic/CMakeLists.txt
+++ b/rellic/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(${PROJECT_NAME} STATIC
   AST/Util.cpp
   AST/Z3CondSimplify.cpp
   AST/Z3ConvVisitor.cpp
+  AST/ReachBasedRefine.cpp
   
   BC/Util.cpp
   BC/Compat/Value.cpp

--- a/tests/tools/decomp/assert.c
+++ b/tests/tools/decomp/assert.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+unsigned long a = 1;
+
+int main(void) {
+    assert(a % 3);
+    assert(a % 7);
+    assert(a % 15);
+    
+    return 0;
+}

--- a/tests/tools/decomp/binops.c
+++ b/tests/tools/decomp/binops.c
@@ -1,4 +1,3 @@
-__attribute__ ((used))
 unsigned int target(unsigned int n) {
   unsigned int mod = n % 4;
   unsigned int result = 0;
@@ -17,5 +16,5 @@ unsigned int target(unsigned int n) {
 }
 
 int main(void) {
-    return 0;
+  return target(0xdeadbeef);
 }

--- a/tools/decomp/Decomp.cpp
+++ b/tools/decomp/Decomp.cpp
@@ -92,23 +92,8 @@ static bool GeneratePseudocode(llvm::Module& module,
   cbr.add(rellic::createNestedCondPropPass(ast_ctx, gen));
   cbr.add(rellic::createNestedScopeCombinerPass(ast_ctx, gen));
   cbr.add(rellic::createCondBasedRefinePass(ast_ctx, gen));
+  cbr.add(rellic::createReachBasedRefinePass(ast_ctx, gen));
   while (cbr.run(module))
-    ;
-
-  // Simplifier to use during reachability-based refinement
-  auto rbr_simplifier = new rellic::Z3CondSimplify(ast_ctx, gen);
-  rbr_simplifier->SetZ3Simplifier(
-      // Simplify boolean structure with AIGs
-      z3::tactic(rbr_simplifier->GetZ3Context(), "aig") &
-      // Cheap local simplifier
-      z3::tactic(rbr_simplifier->GetZ3Context(), "simplify"));
-
-  llvm::legacy::PassManager rbr;
-  rbr.add(rbr_simplifier);
-  rbr.add(rellic::createNestedCondPropPass(ast_ctx, gen));
-  rbr.add(rellic::createNestedScopeCombinerPass(ast_ctx, gen));
-  rbr.add(rellic::createReachBasedRefinePass(ast_ctx, gen));
-  while (rbr.run(module))
     ;
 
   llvm::legacy::PassManager loop;

--- a/tools/decomp/Decomp.cpp
+++ b/tools/decomp/Decomp.cpp
@@ -33,6 +33,7 @@
 #include "rellic/AST/LoopRefine.h"
 #include "rellic/AST/NestedCondProp.h"
 #include "rellic/AST/NestedScopeCombiner.h"
+#include "rellic/AST/ReachBasedRefine.h"
 #include "rellic/AST/Z3CondSimplify.h"
 
 #include "rellic/BC/Util.h"
@@ -92,6 +93,22 @@ static bool GeneratePseudocode(llvm::Module& module,
   cbr.add(rellic::createNestedScopeCombinerPass(ast_ctx, gen));
   cbr.add(rellic::createCondBasedRefinePass(ast_ctx, gen));
   while (cbr.run(module))
+    ;
+
+  // Simplifier to use during reachability-based refinement
+  auto rbr_simplifier = new rellic::Z3CondSimplify(ast_ctx, gen);
+  rbr_simplifier->SetZ3Simplifier(
+      // Simplify boolean structure with AIGs
+      z3::tactic(rbr_simplifier->GetZ3Context(), "aig") &
+      // Cheap local simplifier
+      z3::tactic(rbr_simplifier->GetZ3Context(), "simplify"));
+
+  llvm::legacy::PassManager rbr;
+  rbr.add(rbr_simplifier);
+  rbr.add(rellic::createNestedCondPropPass(ast_ctx, gen));
+  rbr.add(rellic::createNestedScopeCombinerPass(ast_ctx, gen));
+  rbr.add(rellic::createReachBasedRefinePass(ast_ctx, gen));
+  while (rbr.run(module))
     ;
 
   llvm::legacy::PassManager loop;


### PR DESCRIPTION
As subjects suggests and resolves #60. Reachability-based refinement constructs `else-if` cascades when no more `if-then-else` condition-based refinement can be done.