### PR TITLE
Duplicate calls to functions with possible side-effects

### DIFF
--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -40,9 +40,6 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
 
   clang::Expr *CreateLiteralExpr(llvm::Constant *constant);
 
-  clang::VarDecl *CreateVarDecl(clang::DeclContext *decl_ctx, llvm::Type *type,
-                                std::string name);
-
   clang::Expr *CastOperand(clang::QualType dst, clang::Expr *op);
 
  public:
@@ -50,6 +47,8 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
 
   clang::Stmt *GetOrCreateStmt(llvm::Value *val);
   clang::Decl *GetOrCreateDecl(llvm::Value *val);
+
+  void SetStmt(llvm::Value *val, clang::Stmt *stmt);
 
   void VisitGlobalVar(llvm::GlobalVariable &var);
   void VisitFunctionDecl(llvm::Function &func);

--- a/rellic/AST/Util.cpp
+++ b/rellic/AST/Util.cpp
@@ -117,6 +117,14 @@ clang::Expr *CreateOrExpr(clang::ASTContext &ctx, clang::Expr *lhs,
   return CreateBoolBinOp(ctx, clang::BO_LOr, lhs, rhs);
 }
 
+clang::VarDecl *CreateVarDecl(clang::ASTContext &ctx,
+                              clang::DeclContext *decl_ctx,
+                              clang::IdentifierInfo *id, clang::QualType type) {
+  return clang::VarDecl::Create(ctx, decl_ctx, clang::SourceLocation(),
+                                clang::SourceLocation(), id, type, nullptr,
+                                clang::SC_None);
+}
+
 clang::ParmVarDecl *CreateParmVarDecl(clang::ASTContext &ctx,
                                       clang::DeclContext *decl_ctx,
                                       clang::IdentifierInfo *id,

--- a/rellic/AST/Util.h
+++ b/rellic/AST/Util.h
@@ -38,11 +38,19 @@ void InitCompilerInstance(clang::CompilerInstance &ins,
 
 bool ReplaceChildren(clang::Stmt *stmt, StmtMap &repl_map);
 
+template <typename T>
+size_t GetNumDecls(clang::DeclContext *decl_ctx) {
+  size_t result = 0;
+  for (auto decl : decl_ctx->decls()) {
+    if (clang::isa<T>(decl)) {
+      ++result;
+    }
+  }
+  return result;
+}
+
 clang::IdentifierInfo *CreateIdentifier(clang::ASTContext &ctx,
                                         std::string name);
-
-clang::DeclRefExpr *CreateDeclRefExpr(clang::ASTContext &ctx,
-                                      clang::ValueDecl *val);
 
 clang::DoStmt *CreateDoStmt(clang::ASTContext &ctx, clang::Expr *cond,
                             clang::Stmt *body);
@@ -61,6 +69,10 @@ clang::Expr *CreateAndExpr(clang::ASTContext &ctx, clang::Expr *lhs,
 
 clang::Expr *CreateOrExpr(clang::ASTContext &ctx, clang::Expr *lhs,
                           clang::Expr *rhs);
+
+clang::VarDecl *CreateVarDecl(clang::ASTContext &ctx,
+                              clang::DeclContext *decl_ctx,
+                              clang::IdentifierInfo *id, clang::QualType type);
 
 clang::ParmVarDecl *CreateParmVarDecl(clang::ASTContext &ctx,
                                       clang::DeclContext *decl_ctx,

--- a/scripts/roundtrip.py
+++ b/scripts/roundtrip.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("rellic", help="path to rellic-decomp")
     parser.add_argument("tests",
-                        help="path to test file or directory")
+                        help="path to test directory")
     parser.add_argument("clang", help="path to clang")
     parser.add_argument(
         "-t",


### PR DESCRIPTION
Fixes the following

Input:
```llvm
; ModuleID = 'ret666.json'
source_filename = "ret666.json"
target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-pc-linux-gnu-elf"

; Function Attrs: noinline
define i64 @f() local_unnamed_addr #0 {
  ret i64 333
}

; Function Attrs: noinline
define i32 @main(i32, i8**, i8**) local_unnamed_addr #0 {
  %4 = call i64 @f()
  %.sroa.271.2216.extract.trunc = trunc i64 %4 to i32
  %5 = add i32 333, %.sroa.271.2216.extract.trunc
  ret i32 %5
}

attributes #0 = { noinline }
```
Before (master):
```C
unsigned long f();
unsigned int main(unsigned int arg0, unsigned char **arg1, unsigned char **arg2);
unsigned long f() {
    return 333UL;
}
unsigned int main(unsigned int arg0, unsigned char **arg1, unsigned char **arg2) {
    f();
    (unsigned int)(f());
    333U + ((unsigned int)(f()));
    return (333U + ((unsigned int)(f())));
}
```
After:
```C
unsigned long f();
unsigned int main(unsigned int arg0, unsigned char **arg1, unsigned char **arg2);
unsigned long f() {
    return 333UL;
}
unsigned int main(unsigned int arg0, unsigned char **arg1, unsigned char **arg2) {
    unsigned long val0 = f();
    return (333U + ((unsigned int)val0));
}
```