### PR TITLE
Adds `--lower_switch` option...

### DIFF
--- a/tests/tools/decomp/failing/switch.c
+++ b/tests/tools/decomp/failing/switch.c
@@ -1,0 +1,22 @@
+unsigned a = 12;
+int main(void) {
+  int b = 0;
+  switch (a) {
+  case 1:
+    b = 1;
+    break;
+
+  case 12:
+    b = 21;
+    break;
+
+  case 123:
+    b = 321;
+    break;
+
+  default:
+    b = 255;
+    break;
+  }
+  return b;
+}


### PR DESCRIPTION
...for getting rid of llvm::SwitchInst in input bitcode via lowering to branches. Resolves #105 .