### PR TITLE
Adds proper handling of 16-bit integer literals

### DIFF
--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -170,7 +170,18 @@ clang::Expr *IRToASTVisitor::CreateLiteralExpr(llvm::Constant *constant) {
           break;
 
         case clang::BuiltinType::Kind::Short:
+          result = CreateCStyleCastExpr(
+              ast_ctx, ast_ctx.ShortTy, clang::CastKind::CK_IntegralCast,
+              CreateIntegerLiteral(ast_ctx, val, ast_ctx.IntTy));
+          break;
+
         case clang::BuiltinType::Kind::UShort:
+          result = CreateCStyleCastExpr(
+              ast_ctx, ast_ctx.UnsignedShortTy,
+              clang::CastKind::CK_IntegralCast,
+              CreateIntegerLiteral(ast_ctx, val, ast_ctx.UnsignedIntTy));
+          break;
+
         case clang::BuiltinType::Kind::Int:
         case clang::BuiltinType::Kind::UInt:
         case clang::BuiltinType::Kind::Long:

--- a/tests/tools/decomp/short.c
+++ b/tests/tools/decomp/short.c
@@ -1,0 +1,7 @@
+unsigned short a;
+int main(void) {
+  unsigned short b;
+  a = 13;
+  b = a;
+  return b;
+}


### PR DESCRIPTION
Basically for a 16-bit `42` literal we emit `(unsigned short) 42U`. Resolves #104 .