### PR TITLE
Skip annotation intrinsics when translating to C

### DIFF
--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -240,8 +240,10 @@ clang::Expr *IRToASTVisitor::CreateLiteralExpr(llvm::Constant *constant) {
   return result;
 }
 
-#define ASSERT_ON_VALUE_TYPE(x) \
-  if (llvm::isa<x>(val)) { LOG(FATAL) << "Invalid operand [" #x "]"; }
+#define ASSERT_ON_VALUE_TYPE(x)               \
+  if (llvm::isa<x>(val)) {                    \
+    LOG(FATAL) << "Invalid operand [" #x "]"; \
+  }
 
 clang::Expr *IRToASTVisitor::GetOperandExpr(llvm::Value *val) {
   DLOG(INFO) << "Getting Expr for " << LLVMThingToString(val);
@@ -415,7 +417,7 @@ void IRToASTVisitor::VisitFunctionDecl(llvm::Function &func) {
   auto name = func.getName().str();
   DLOG(INFO) << "VisitFunctionDecl: " << name;
 
-  if(IsAnnotationIntrinsic(func.getIntrinsicID())) {
+  if (IsAnnotationIntrinsic(func.getIntrinsicID())) {
     DLOG(INFO) << "Skipping creating declaration for LLVM intrinsic";
     return;
   }
@@ -459,11 +461,11 @@ void IRToASTVisitor::visitIntrinsicInst(llvm::IntrinsicInst &inst) {
     DLOG(INFO) << "Skipping debug data intrinsic";
     return;
   } else if (IsAnnotationIntrinsic(inst.getIntrinsicID())) {
-      // Some of this overlaps with the debug data case above.
-      // This is fine. We want debug data special cased as we know it is present
-      // and we may make use of it earlier than other annotations
-      DLOG(INFO) << "Skipping non-debug annotation";
-      return;
+    // Some of this overlaps with the debug data case above.
+    // This is fine. We want debug data special cased as we know it is present
+    // and we may make use of it earlier than other annotations
+    DLOG(INFO) << "Skipping non-debug annotation";
+    return;
   }
 
   // handle this as a CallInst, which IntrinsicInst derives from

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -364,7 +364,7 @@ clang::Decl *IRToASTVisitor::GetOrCreateDecl(llvm::Value *val) {
 }
 
 void IRToASTVisitor::VisitGlobalVar(llvm::GlobalVariable &gvar) {
-  LOG(ERROR) << "VisitGlobalVar: " << LLVMThingToString(&gvar);
+  DLOG(INFO) << "VisitGlobalVar: " << LLVMThingToString(&gvar);
   auto &var = value_decls[&gvar];
   if (var) {
     return;

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -25,6 +25,7 @@
 
 #include "rellic/AST/Util.h"
 #include "rellic/BC/Compat/Value.h"
+#include "rellic/BC/Compat/IntrinsicInst.h"
 #include "rellic/BC/Util.h"
 
 namespace rellic {

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -24,8 +24,8 @@
 #include <iterator>
 
 #include "rellic/AST/Util.h"
-#include "rellic/BC/Compat/Value.h"
 #include "rellic/BC/Compat/IntrinsicInst.h"
+#include "rellic/BC/Compat/Value.h"
 #include "rellic/BC/Util.h"
 
 namespace rellic {

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -364,9 +364,14 @@ clang::Decl *IRToASTVisitor::GetOrCreateDecl(llvm::Value *val) {
 }
 
 void IRToASTVisitor::VisitGlobalVar(llvm::GlobalVariable &gvar) {
-  DLOG(INFO) << "VisitGlobalVar: " << LLVMThingToString(&gvar);
+  LOG(ERROR) << "VisitGlobalVar: " << LLVMThingToString(&gvar);
   auto &var = value_decls[&gvar];
   if (var) {
+    return;
+  }
+
+  if (IsGlobalMetadata(gvar)) {
+    DLOG(INFO) << "Skipping global variable only used for metadata";
     return;
   }
 

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -460,7 +460,9 @@ void IRToASTVisitor::visitIntrinsicInst(llvm::IntrinsicInst &inst) {
   if (llvm::isDbgInfoIntrinsic(inst.getIntrinsicID())) {
     DLOG(INFO) << "Skipping debug data intrinsic";
     return;
-  } else if (IsAnnotationIntrinsic(inst.getIntrinsicID())) {
+  }
+  
+  if (IsAnnotationIntrinsic(inst.getIntrinsicID())) {
     // Some of this overlaps with the debug data case above.
     // This is fine. We want debug data special cased as we know it is present
     // and we may make use of it earlier than other annotations
@@ -937,13 +939,9 @@ void IRToASTVisitor::visitCastInst(llvm::CastInst &inst) {
     return;
   }
 
-  auto oper = inst.getOperand(0);
-  if (!oper) {
-    return;
-  }
-
-  // Get cast operand
-  auto operand = GetOperandExpr(oper);
+  // There should always be an operand with a cast instruction
+  // Get a C-language expression of the operand
+  auto operand = GetOperandExpr(inst.getOperand(0));
   // Get destination type
   auto type = GetQualType(inst.getType());
   // Convenience wrapper

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -444,36 +444,36 @@ void IRToASTVisitor::visitIntrinsicInst(llvm::IntrinsicInst &inst) {
   // All it does it lead to triggering of asserts for things that are
   // low-priority on the "to fix" list
 
-  if (llvm::IsDbgInfoIntrinsic(inst.getIntrinsicID()) {
+  if (llvm::isDbgInfoIntrinsic(inst.getIntrinsicID())) {
     DLOG(INFO) << "Skipping debug data intrinsic";
     return;
-  } else if (inst.IsAssumeLikeIntrinsic()) {
-    // This should handle approximately the following intrinsics:
-    //
-    // case Intrinsic::assume:
-    // case Intrinsic::sideeffect:
-    // case Intrinsic::pseudoprobe:
-    // case Intrinsic::dbg_declare:
-    // case Intrinsic::dbg_value:
-    // case Intrinsic::dbg_label:
-    // case Intrinsic::invariant_start:
-    // case Intrinsic::invariant_end:
-    // case Intrinsic::lifetime_start:
-    // case Intrinsic::lifetime_end:
-    // case Intrinsic::experimental_noalias_scope_decl:
-    // case Intrinsic::objectsize:
-    // case Intrinsic::ptr_annotation:
-    // case Intrinsic::var_annotation:
-    //
-    // Some of this overlaps with the debug data case above.
-    // This is fine. We want debug data special cased as we know it is present
-    // and we may make use of it earlier than other annotations
-    DLOG(INFO) << "Skipping non-debug annotation";
-    return;
-  } else {
-    // handle this as a CallInst, which IntrinsicInst derives from
-    return visitCallInst(inst);
   }
+
+  // this is a copy of IntrinsicInst::isAssumeLikeIntrinsic in LLVM12+
+  switch (inst.getIntrinsicID()) {
+      // Some of this overlaps with the debug data case above.
+      // This is fine. We want debug data special cased as we know it is present
+      // and we may make use of it earlier than other annotations
+    case llvm::Intrinsic::assume:
+    case llvm::Intrinsic::sideeffect:
+    //case llvm::Intrinsic::pseudoprobe:
+    case llvm::Intrinsic::dbg_declare:
+    case llvm::Intrinsic::dbg_value:
+    case llvm::Intrinsic::dbg_label:
+    case llvm::Intrinsic::invariant_start:
+    case llvm::Intrinsic::invariant_end:
+    case llvm::Intrinsic::lifetime_start:
+    case llvm::Intrinsic::lifetime_end:
+    //case llvm::Intrinsic::experimental_noalias_scope_decl:
+    case llvm::Intrinsic::objectsize:
+    case llvm::Intrinsic::ptr_annotation:
+    case llvm::Intrinsic::var_annotation:
+      DLOG(INFO) << "Skipping non-debug annotation";
+      return;
+  }
+
+  // handle this as a CallInst, which IntrinsicInst derives from
+  return visitCallInst(inst);
 }
 
 void IRToASTVisitor::visitCallInst(llvm::CallInst &inst) {

--- a/rellic/AST/IRToASTVisitor.h
+++ b/rellic/AST/IRToASTVisitor.h
@@ -56,6 +56,7 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   void VisitFunctionDecl(llvm::Function &func);
   void VisitArgument(llvm::Argument &arg);
 
+  void visitIntrinsicInst(llvm::IntrinsicInst &inst);
   void visitCallInst(llvm::CallInst &inst);
   void visitGetElementPtrInst(llvm::GetElementPtrInst &inst);
   void visitExtractValueInst(llvm::ExtractValueInst &inst);

--- a/rellic/AST/Util.cpp
+++ b/rellic/AST/Util.cpp
@@ -79,6 +79,8 @@ clang::IdentifierInfo *CreateIdentifier(clang::ASTContext &ctx,
 
 clang::DeclRefExpr *CreateDeclRefExpr(clang::ASTContext &ast_ctx,
                                       clang::ValueDecl *val) {
+  CHECK(val) << "should not be null in CreateDeclRefExpr";
+
   DLOG(INFO) << "Creating DeclRefExpr for " << val->getNameAsString();
   return clang::DeclRefExpr::Create(
       ast_ctx, clang::NestedNameSpecifierLoc(), clang::SourceLocation(), val,

--- a/rellic/BC/Compat/IntrinsicInst.h
+++ b/rellic/BC/Compat/IntrinsicInst.h
@@ -1,0 +1,17 @@
+#include "rellic/BC/Version.h"
+
+#if LLVM_VERSION_NUMBER < LLVM_VERSION(11, 0)
+namespace llvm {
+static inline bool isDbgInfoIntrinsic(Intrinsic::ID ID) {
+  switch (ID) {
+  case Intrinsic::dbg_declare:
+  case Intrinsic::dbg_value:
+  case Intrinsic::dbg_addr:
+  case Intrinsic::dbg_label:
+    return true;
+  default:
+    return false;
+  }
+}
+} // namespace llvm
+#endif

--- a/rellic/BC/Compat/IntrinsicInst.h
+++ b/rellic/BC/Compat/IntrinsicInst.h
@@ -16,3 +16,11 @@ static inline bool isDbgInfoIntrinsic(Intrinsic::ID ID) {
 }
 } // namespace llvm
 #endif
+
+namespace Intrinsic {
+#if LLVM_VERSION_NUMBER < LLVM_VERSION(10, 0)
+enum ID : unsigned;
+#else
+typedef unsigned ID;
+#endif
+}  // namespace Intrinsic

--- a/rellic/BC/Compat/IntrinsicInst.h
+++ b/rellic/BC/Compat/IntrinsicInst.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/IntrinsicInst.h"
 #include "rellic/BC/Version.h"
 
 #if LLVM_VERSION_NUMBER < LLVM_VERSION(11, 0)

--- a/rellic/BC/Compat/IntrinsicInst.h
+++ b/rellic/BC/Compat/IntrinsicInst.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "llvm/IR/IntrinsicInst.h"
 #include "rellic/BC/Version.h"
 

--- a/rellic/BC/Util.cpp
+++ b/rellic/BC/Util.cpp
@@ -109,4 +109,27 @@ llvm::Module *LoadModuleFromFile(llvm::LLVMContext *context,
   return module;
 }
 
+bool IsAnnotationIntrinsic(llvm::Intrinsic::ID id) {
+  // this is a copy of IntrinsicInst::isAssumeLikeIntrinsic in LLVM12+
+  // NOTE(artem): This probalby needs some compat wrappers for older LLVM
+  switch (id) {
+    case llvm::Intrinsic::assume:
+    case llvm::Intrinsic::sideeffect:
+    // case llvm::Intrinsic::pseudoprobe:
+    case llvm::Intrinsic::dbg_declare:
+    case llvm::Intrinsic::dbg_value:
+    case llvm::Intrinsic::dbg_label:
+    case llvm::Intrinsic::invariant_start:
+    case llvm::Intrinsic::invariant_end:
+    case llvm::Intrinsic::lifetime_start:
+    case llvm::Intrinsic::lifetime_end:
+    // case llvm::Intrinsic::experimental_noalias_scope_decl:
+    case llvm::Intrinsic::objectsize:
+    case llvm::Intrinsic::ptr_annotation:
+    case llvm::Intrinsic::var_annotation:
+      return false;
+  }
+  return true;
+}
+
 }  // namespace rellic

--- a/rellic/BC/Util.cpp
+++ b/rellic/BC/Util.cpp
@@ -132,8 +132,9 @@ bool IsAnnotationIntrinsic(llvm::Intrinsic::ID id) {
     case llvm::Intrinsic::ptr_annotation:
     case llvm::Intrinsic::var_annotation:
       return true;
+    default:
+      return false;
   }
-  return false;
 }
 
 }  // namespace rellic

--- a/rellic/BC/Util.cpp
+++ b/rellic/BC/Util.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#include "rellic/BC/Util.h"
+
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-
 #include <llvm/ADT/SmallVector.h>
-
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/IRBuilder.h>
@@ -27,7 +27,6 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
-
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Support/raw_ostream.h>
@@ -35,7 +34,6 @@
 #include "rellic/BC/Compat/Error.h"
 #include "rellic/BC/Compat/IRReader.h"
 #include "rellic/BC/Compat/Verifier.h"
-#include "rellic/BC/Util.h"
 
 namespace rellic {
 

--- a/rellic/BC/Util.cpp
+++ b/rellic/BC/Util.cpp
@@ -109,6 +109,10 @@ llvm::Module *LoadModuleFromFile(llvm::LLVMContext *context,
   return module;
 }
 
+bool IsGlobalMetadata(const llvm::GlobalObject &go) {
+  return go.getSection() == "llvm.metadata";
+}
+
 bool IsAnnotationIntrinsic(llvm::Intrinsic::ID id) {
   // this is a copy of IntrinsicInst::isAssumeLikeIntrinsic in LLVM12+
   // NOTE(artem): This probalby needs some compat wrappers for older LLVM
@@ -127,9 +131,9 @@ bool IsAnnotationIntrinsic(llvm::Intrinsic::ID id) {
     case llvm::Intrinsic::objectsize:
     case llvm::Intrinsic::ptr_annotation:
     case llvm::Intrinsic::var_annotation:
-      return false;
+      return true;
   }
-  return true;
+  return false;
 }
 
 }  // namespace rellic

--- a/rellic/BC/Util.h
+++ b/rellic/BC/Util.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string>
+#include "rellic/BC/Compat/IntrinsicInst.h"
 
 namespace llvm {
 class Module;
@@ -24,11 +25,6 @@ class Type;
 class Value;
 class LLVMContext;
 class GlobalObject;
-
-namespace Intrinsic {
-typedef unsigned ID;
-}  // namespace Intrinsic
-
 }  // namespace llvm
 
 namespace rellic {

--- a/rellic/BC/Util.h
+++ b/rellic/BC/Util.h
@@ -23,6 +23,12 @@ class Module;
 class Type;
 class Value;
 class LLVMContext;
+class GlobalObject;
+
+namespace Intrinsic {
+typedef unsigned ID;
+}  // namespace Intrinsic
+
 }  // namespace llvm
 
 namespace rellic {

--- a/rellic/BC/Util.h
+++ b/rellic/BC/Util.h
@@ -38,6 +38,10 @@ llvm::Module *LoadModuleFromFile(llvm::LLVMContext *context,
                                  std::string file_name,
                                  bool allow_failure = false);
 
+// Check if an intrinsic ID is an annotation
 bool IsAnnotationIntrinsic(llvm::Intrinsic::ID id);
+
+// check if a global object is llvm metadata
+bool IsGlobalMetadata(const llvm::GlobalObject &go);
 
 }  // namespace rellic

--- a/rellic/BC/Util.h
+++ b/rellic/BC/Util.h
@@ -37,4 +37,7 @@ bool VerifyModule(llvm::Module *module);
 llvm::Module *LoadModuleFromFile(llvm::LLVMContext *context,
                                  std::string file_name,
                                  bool allow_failure = false);
+
+bool IsAnnotationIntrinsic(llvm::Intrinsic::ID id);
+
 }  // namespace rellic


### PR DESCRIPTION
* Skip annotation intrinsic functions
* Skip global variables that go into metadata like llvm.used