### PR TITLE
Disables Tseitin-CNF and adds minor z3 operation handlers

### DIFF
--- a/rellic/AST/Z3CondSimplify.cpp
+++ b/rellic/AST/Z3CondSimplify.cpp
@@ -25,13 +25,13 @@ Z3CondSimplify::Z3CondSimplify(clang::ASTUnit &unit,
       z3_simplifier(*z3_ctx, "simplify") {}
 
 clang::Expr *Z3CondSimplify::SimplifyCExpr(clang::Expr *c_expr) {
-  auto z3_expr = z3_gen->GetOrCreateZ3Expr(c_expr);
+  auto z3_expr{z3_gen->GetOrCreateZ3Expr(c_expr)};
   z3::goal goal(*z3_ctx);
   goal.add(z3_expr);
   // Apply on `z3_simplifier` on condition
   auto app{z3_simplifier(goal)};
   CHECK(app.size() == 1) << "Unexpected multiple goals in application!";
-  auto z3_result = app[0].as_expr();
+  auto z3_result{app[0].as_expr()};
   return z3_gen->GetOrCreateCExpr(z3_result);
 }
 

--- a/rellic/AST/Z3ConvVisitor.cpp
+++ b/rellic/AST/Z3ConvVisitor.cpp
@@ -993,6 +993,13 @@ void Z3ConvVisitor::VisitUnaryApp(z3::expr z_op) {
 
     } break;
 
+    case Z3_OP_ZERO_EXT:
+      c_op = ast.CreateCStyleCast(
+          ast.GetLeastIntTypeForBitWidth(GetZ3SortSize(z_op),
+                                         /*sign=*/0),
+          ast.CreateParen(c_sub));
+      break;
+
     case Z3_OP_SIGN_EXT:
       c_op = ast.CreateCStyleCast(
           ast.GetLeastIntTypeForBitWidth(GetZ3SortSize(z_op),
@@ -1094,6 +1101,10 @@ void Z3ConvVisitor::VisitBinaryApp(z3::expr z_op) {
 
     case Z3_OP_BSHL:
       c_op = ast.CreateShl(lhs, rhs);
+      break;
+
+    case Z3_OP_BAND:
+      c_op = ast.CreateAnd(lhs, rhs);
       break;
 
     case Z3_OP_BOR:

--- a/tools/decomp/Decomp.cpp
+++ b/tools/decomp/Decomp.cpp
@@ -79,7 +79,8 @@ static bool GeneratePseudocode(llvm::Module& module,
                                llvm::raw_ostream& output) {
   InitOptPasses();
 
-  std::vector<std::string> args{"-Wno-pointer-to-int-cast", "-target", module.getTargetTriple()};
+  std::vector<std::string> args{"-Wno-pointer-to-int-cast", "-target",
+                                module.getTargetTriple()};
   auto ast_unit{clang::tooling::buildASTFromCodeWithArgs("", args, "out.c")};
   auto& ast_ctx{ast_unit->getASTContext()};
 
@@ -125,12 +126,10 @@ static bool GeneratePseudocode(llvm::Module& module,
   fin_simplifier->SetZ3Simplifier(
       // Simplify boolean structure with AIGs
       z3::tactic(fin_simplifier->GetZ3Context(), "aig") &
+      // Solve equations
+      z3::tactic(fin_simplifier->GetZ3Context(), "solve-eqs") &
       // Propagate bounds over bit-vectors
       z3::tactic(fin_simplifier->GetZ3Context(), "propagate-bv-bounds") &
-      // Eliminate conjunctions using De Morgan laws
-      z3::tactic(fin_simplifier->GetZ3Context(), "elim-and") &
-      // Tseitin transformation
-      z3::tactic(fin_simplifier->GetZ3Context(), "tseitin-cnf") &
       // Contextual simplification
       z3::tactic(fin_simplifier->GetZ3Context(), "ctx-simplify"));
 


### PR DESCRIPTION
The `tseitin-cnf` tactic was used to help with the final simplification of conditions, but in some cases it introduces auxiliary variables that don't have an equivalent in C.

Also adds `Z3_OP_BAND` and `Z3_OP_ZERO_EXT` handlers to `Z3ConvVisitor`