### PR TITLE
Support angha testing on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ cd rellic-build #or your rellic build directory
 CTEST_OUTPUT_ON_FAILURE=1 cmake --build . --verbose --target test
 ```
 
-*AnghaBench 1000* is a sample of 1000 files (x 4 architectures, so a total of 4000 tests) from the full million programs that come with AnghaBench. This test only checks whether the bitcode for these programs translates to C, not the prettiness or functionality of the resulting translation. This test is only supported on Linux. To run this test, use:
+*AnghaBench 1000* is a sample of 1000 files (x 4 architectures, so a total of 4000 tests) from the full million programs that come with AnghaBench. This test only checks whether the bitcode for these programs translates to C, not the prettiness or functionality of the resulting translation. To run this test, first install the required Python dependencies found in `scripts/requirements.txt` and then run:
 
 ```sh
-scripts/test-angha-1k.sh --rellic-cmd <path_to_rellic_exe>
+scripts/test-angha-1k.sh --rellic-cmd <path_to_rellic_decompiler_exe>
 ```

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+# test-angha-1k.sh python requirements
+tqdm
+requests

--- a/scripts/test-angha-1k.sh
+++ b/scripts/test-angha-1k.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SRC_DIR=$( cd "$( dirname "${DIR}" )" && pwd )
 


### PR DESCRIPTION
Uses /usr/bin/env to lookup bash executable because macOS ships with old
version at /bin/bash

Updated README with Python requirements