### PR TITLE
Fix handling of undef integer values.

### DIFF
--- a/rellic/AST/ASTBuilder.cpp
+++ b/rellic/AST/ASTBuilder.cpp
@@ -171,7 +171,7 @@ clang::Expr *ASTBuilder::CreateUndefInteger(clang::QualType type) {
 clang::Expr *ASTBuilder::CreateUndefPointer(clang::QualType type) {
   auto null{CreateNull()};
   auto cast{CreateCStyleCast(ctx.getPointerType(type), null)};
-  return CreateDeref(cast);
+  return cast;
 };
 
 clang::IdentifierInfo *ASTBuilder::CreateIdentifier(std::string name) {

--- a/rellic/AST/ASTBuilder.cpp
+++ b/rellic/AST/ASTBuilder.cpp
@@ -162,7 +162,13 @@ clang::Expr *ASTBuilder::CreateNull() {
   return CreateCStyleCast(ctx.VoidPtrTy, lit);
 };
 
-clang::Expr *ASTBuilder::CreateUndef(clang::QualType type) {
+clang::Expr *ASTBuilder::CreateUndefInteger(clang::QualType type) {
+  auto val{llvm::APInt::getNullValue(ctx.getTypeSize(type))};
+  auto lit{CreateIntLit(val)};
+  return lit;
+};
+
+clang::Expr *ASTBuilder::CreateUndefPointer(clang::QualType type) {
   auto null{CreateNull()};
   auto cast{CreateCStyleCast(ctx.getPointerType(type), null)};
   return CreateDeref(cast);

--- a/rellic/AST/ASTBuilder.h
+++ b/rellic/AST/ASTBuilder.h
@@ -54,7 +54,8 @@ class ASTBuilder {
   };
   // Special values
   clang::Expr *CreateNull();
-  clang::Expr *CreateUndef(clang::QualType type);
+  clang::Expr *CreateUndefPointer(clang::QualType type);
+  clang::Expr *CreateUndefInteger(clang::QualType type);
   // Identifiers
   clang::IdentifierInfo *CreateIdentifier(std::string name);
   // Variable declaration

--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -159,12 +159,7 @@ clang::Expr *IRToASTVisitor::CreateLiteralExpr(llvm::Constant *constant) {
           result = ast.CreateAdjustedIntLit(val);
         }
       } else if (llvm::isa<llvm::UndefValue>(constant)) {
-        //NOTE(artem):
-        // This gives the following result:
-        // warning: indirection of non-volatile null pointer will be deleted, not trap [-Wnull-dereference]
-        // note: consider using __builtin_trap() or qualifying pointer with 'volatile'
-        // We may want to consider making a CreteTrap() instead?
-        result = ast.CreateUndef(c_type);
+        result = ast.CreateUndefInteger(c_type);
       } else {
         LOG(FATAL) << "Unsupported integer constant";
       }
@@ -174,7 +169,7 @@ clang::Expr *IRToASTVisitor::CreateLiteralExpr(llvm::Constant *constant) {
       if (llvm::isa<llvm::ConstantPointerNull>(constant)) {
         result = ast.CreateNull();
       } else if (llvm::isa<llvm::UndefValue>(constant)) {
-        result = ast.CreateUndef(c_type);
+        result = ast.CreateUndefPointer(c_type);
       } else {
         LOG(FATAL) << "Unsupported pointer constant";
       }

--- a/unittests/AST/ASTBuilder.cpp
+++ b/unittests/AST/ASTBuilder.cpp
@@ -267,8 +267,8 @@ TEST_SUITE("ASTBuilder::CreateNull") {
   }
 }
 
-TEST_SUITE("ASTBuilder::CreateUndefInteger") {
-  SCENARIO("Create clang::Expr to stand in for an undefined integer") {
+TEST_SUITE("ASTBuilder::CreateUndef") {
+  SCENARIO("Create clang::Expr to stand in for LLVM's 'undef' values") {
     GIVEN("Empty clang::ASTContext") {
       auto unit{GetASTUnit()};
       auto &ctx{unit->getASTContext()};
@@ -281,27 +281,13 @@ TEST_SUITE("ASTBuilder::CreateUndefInteger") {
           CHECK(expr->getType() == ctx.UnsignedIntTy);
         }
       }
-    }
-  }
-}
-
-TEST_SUITE("ASTBuilder::CreateUndefPointer") {
-  SCENARIO("Create clang::Expr whose value is undefined") {
-    GIVEN("Empty clang::ASTContext") {
-      auto unit{GetASTUnit()};
-      auto &ctx{unit->getASTContext()};
-      rellic::ASTBuilder ast(*unit);
       GIVEN("an arbitrary type t") {
         auto type{ctx.DoubleTy};
-        THEN("return a null pointer dereference of type t") {
+        THEN("return an undef pointer (we use null pointers) of type t") {
           auto expr{ast.CreateUndefPointer(type)};
           REQUIRE(expr != nullptr);
           CHECK(expr->getType() == ctx.DoubleTy);
-          auto deref{clang::dyn_cast<clang::UnaryOperator>(expr)};
-          REQUIRE(deref != nullptr);
-          CHECK(deref->getOpcode() == clang::UO_Deref);
-          IsNullPtrExprCheck(ctx, deref->getSubExpr()->IgnoreCasts());
-        }
+          IsNullPtrExprCheck(ctx, expr->IgnoreCasts());
       }
     }
   }

--- a/unittests/AST/ASTBuilder.cpp
+++ b/unittests/AST/ASTBuilder.cpp
@@ -288,7 +288,8 @@ TEST_SUITE("ASTBuilder::CreateUndef") {
         THEN("return an undef pointer (we use null pointers) of type t") {
           auto expr{ast.CreateUndefPointer(type)};
           REQUIRE(expr != nullptr);
-          CHECK(expr->getType() == ctx.DoubleTy);
+          auto double_ptr_ty{ctx.getPointerType(ctx.DoubleTy)};
+          CHECK(expr->getType() == double_ptr_ty);
           IsNullPtrExprCheck(ctx, expr->IgnoreCasts());
         }
       }

--- a/unittests/AST/ASTBuilder.cpp
+++ b/unittests/AST/ASTBuilder.cpp
@@ -275,7 +275,9 @@ TEST_SUITE("ASTBuilder::CreateUndef") {
       rellic::ASTBuilder ast(*unit);
       GIVEN("an unsigned integer type") {
         auto type{ctx.UnsignedIntTy};
-        THEN("return a value that satisfied LLVM's undef semantics (aka anything)") {
+        THEN(
+            "return a value that satisfied LLVM's undef semantics (aka "
+            "anything)") {
           auto expr{ast.CreateUndefInteger(type)};
           REQUIRE(expr != nullptr);
           CHECK(expr->getType() == ctx.UnsignedIntTy);
@@ -288,6 +290,7 @@ TEST_SUITE("ASTBuilder::CreateUndef") {
           REQUIRE(expr != nullptr);
           CHECK(expr->getType() == ctx.DoubleTy);
           IsNullPtrExprCheck(ctx, expr->IgnoreCasts());
+        }
       }
     }
   }

--- a/unittests/AST/ASTBuilder.cpp
+++ b/unittests/AST/ASTBuilder.cpp
@@ -267,7 +267,25 @@ TEST_SUITE("ASTBuilder::CreateNull") {
   }
 }
 
-TEST_SUITE("ASTBuilder::CreateUndef") {
+TEST_SUITE("ASTBuilder::CreateUndefInteger") {
+  SCENARIO("Create clang::Expr to stand in for an undefined integer") {
+    GIVEN("Empty clang::ASTContext") {
+      auto unit{GetASTUnit()};
+      auto &ctx{unit->getASTContext()};
+      rellic::ASTBuilder ast(*unit);
+      GIVEN("an unsigned integer type") {
+        auto type{ctx.UnsignedIntTy};
+        THEN("return a value that satisfied LLVM's undef semantics (aka anything)") {
+          auto expr{ast.CreateUndefInteger(type)};
+          REQUIRE(expr != nullptr);
+          CHECK(expr->getType() == ctx.UnsignedIntTy);
+        }
+      }
+    }
+  }
+}
+
+TEST_SUITE("ASTBuilder::CreateUndefPointer") {
   SCENARIO("Create clang::Expr whose value is undefined") {
     GIVEN("Empty clang::ASTContext") {
       auto unit{GetASTUnit()};
@@ -276,7 +294,7 @@ TEST_SUITE("ASTBuilder::CreateUndef") {
       GIVEN("an arbitrary type t") {
         auto type{ctx.DoubleTy};
         THEN("return a null pointer dereference of type t") {
-          auto expr{ast.CreateUndef(type)};
+          auto expr{ast.CreateUndefPointer(type)};
           REQUIRE(expr != nullptr);
           CHECK(expr->getType() == ctx.DoubleTy);
           auto deref{clang::dyn_cast<clang::UnaryOperator>(expr)};


### PR DESCRIPTION
Fix handling of `undef` integer values
This was the source of a segfault due to a failed cast.