### PR TITLE
Add a default handler for addrspace casts

### DIFF
--- a/rellic/AST/IRToASTVisitor.cpp
+++ b/rellic/AST/IRToASTVisitor.cpp
@@ -806,6 +806,14 @@ void IRToASTVisitor::visitCastInst(llvm::CastInst &inst) {
       type = ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/1);
     } break;
 
+    case llvm::CastInst::AddrSpaceCast:
+    //NOTE(artem): ignore addrspace casts for now, but eventually we want to
+    // handle them as __thread or some other context-relative handler
+    // which will *highly* depend on the target architecture
+    DLOG(WARNING) << __FUNCTION__ << ": Ignoring an AddrSpaceCast because it is not yet implemented.";
+    // The fallthrough is intentional here
+    [[clang::fallthrough]];
+
     case llvm::CastInst::ZExt:
     case llvm::CastInst::BitCast:
     case llvm::CastInst::PtrToInt:


### PR DESCRIPTION
Adds a default handler for addrspace casts to get at least some output for bitcode that uses these. Filed issue #160 to track a more comprehensive solution.