### PR TITLE
Adds rules for elimination of ternary conditionals and casts

### DIFF
--- a/rellic/AST/ExprCombine.cpp
+++ b/rellic/AST/ExprCombine.cpp
@@ -280,7 +280,6 @@ class TripleCStyleCastElimRule : public InferenceRule {
             ctx.getTypeSize(subsubcast->getType()) &&
         ctx.getTypeSize(cast->getType()) <=
             ctx.getTypeSize(subcast->getType())) {
-      LOG(FATAL) << "SATAN";
       return ASTBuilder(unit).CreateCStyleCast(cast->getType(), subsubcast);
     }
 

--- a/rellic/AST/Z3CondSimplify.cpp
+++ b/rellic/AST/Z3CondSimplify.cpp
@@ -20,9 +20,9 @@ Z3CondSimplify::Z3CondSimplify(clang::ASTUnit &unit,
     : ModulePass(Z3CondSimplify::ID),
       ast_ctx(&unit.getASTContext()),
       ast_gen(&ast_gen),
-      z3_ctx(new z3::context()),
-      z3_gen(new rellic::Z3ConvVisitor(unit, z3_ctx.get())),
-      z3_simplifier(*z3_ctx, "simplify") {}
+      z_ctx(new z3::context()),
+      z_gen(new rellic::Z3ConvVisitor(unit, z_ctx.get())),
+      simplifier(*z_ctx, "simplify") {}
 
 clang::Expr *Z3CondSimplify::SimplifyCExpr(clang::Expr *c_expr) {
   auto z3_expr{z3_gen->GetOrCreateZ3Expr(c_expr)};

--- a/rellic/AST/Z3CondSimplify.cpp
+++ b/rellic/AST/Z3CondSimplify.cpp
@@ -25,14 +25,14 @@ Z3CondSimplify::Z3CondSimplify(clang::ASTUnit &unit,
       simplifier(*z_ctx, "simplify") {}
 
 clang::Expr *Z3CondSimplify::SimplifyCExpr(clang::Expr *c_expr) {
-  auto z3_expr{z3_gen->GetOrCreateZ3Expr(c_expr)};
-  z3::goal goal(*z3_ctx);
-  goal.add(z3_expr);
-  // Apply on `z3_simplifier` on condition
-  auto app{z3_simplifier(goal)};
+  auto z_expr{z_gen->GetOrCreateZ3Expr(c_expr)};
+  z3::goal goal(*z_ctx);
+  goal.add(z_expr);
+  // Apply on `simplifier` on condition
+  auto app{simplifier(goal)};
   CHECK(app.size() == 1) << "Unexpected multiple goals in application!";
-  auto z3_result{app[0].as_expr()};
-  return z3_gen->GetOrCreateCExpr(z3_result);
+  auto z_result{app[0].as_expr()};
+  return z_gen->GetOrCreateCExpr(z_result);
 }
 
 bool Z3CondSimplify::VisitIfStmt(clang::IfStmt *stmt) {

--- a/rellic/AST/Z3CondSimplify.h
+++ b/rellic/AST/Z3CondSimplify.h
@@ -23,10 +23,10 @@ class Z3CondSimplify : public llvm::ModulePass,
  private:
   clang::ASTContext *ast_ctx;
   rellic::IRToASTVisitor *ast_gen;
-  std::unique_ptr<z3::context> z3_ctx;
-  std::unique_ptr<rellic::Z3ConvVisitor> z3_gen;
+  std::unique_ptr<z3::context> z_ctx;
+  std::unique_ptr<rellic::Z3ConvVisitor> z_gen;
 
-  z3::tactic z3_simplifier;
+  z3::tactic simplifier;
 
   clang::Expr *SimplifyCExpr(clang::Expr *c_expr);
 
@@ -35,9 +35,9 @@ class Z3CondSimplify : public llvm::ModulePass,
 
   Z3CondSimplify(clang::ASTUnit &unit, rellic::IRToASTVisitor &ast_gen);
 
-  z3::context &GetZ3Context() { return *z3_ctx; }
+  z3::context &GetZ3Context() { return *z_ctx; }
 
-  void SetZ3Simplifier(z3::tactic tactic) { z3_simplifier = tactic; };
+  void SetZ3Simplifier(z3::tactic tactic) { simplifier = tactic; };
 
   bool VisitIfStmt(clang::IfStmt *stmt);
   bool VisitWhileStmt(clang::WhileStmt *loop);


### PR DESCRIPTION
Eliminates explicit widening integer cast expressions whose effect is negated by a subsequent narrowing cast, i.e:
```C
(unsigned)(long long)(int)expr
```
to
```C
(int)(char)expr
```
also rewrites ternary conditionals of form
```C
cond ? 1U : 0U
```
to
```C
cond
```