### PR TITLE
Fix missing dependencies in Linux build example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Pre-built Docker images are available on [Docker Hub](https://hub.docker.com/rep
 First, update aptitude and get install the baseline dependencies.
 
 ```shell
-sudo apt-get update
-sudo apt-get upgrade
+sudo apt update
+sudo apt upgrade
 
-sudo apt-get install \
+sudo apt install \
      git \
      python3 \
      wget \
@@ -58,7 +58,8 @@ sudo apt-get install \
      build-essential \
      lsb-release \
      zlib1g-dev \
-     libomp-dev
+     libomp-dev \
+     doctest-dev
 ```
 
 If the distribution you're on doesn't include a recent release of CMake (3.14 or later), you'll need to install it. For Ubuntu, see here https://apt.kitware.com/.
@@ -131,7 +132,7 @@ and
 
 We use several integration and unit tests to test rellic.
 
-*Roundtrip tests* will take C code, build it to LLVM IR, and then translate that IR back to C. The test then sees if the resuling C can be built and if the translated code does (roughly) the same thing as the original. To run these, use:
+*Roundtrip tests* will take C code, build it to LLVM IR, and then translate that IR back to C. The test then sees if the resulting C can be built and if the translated code does (roughly) the same thing as the original. To run these, use:
 
 ```sh
 cd rellic-build #or your rellic build directory


### PR DESCRIPTION
From the commit message:

> The `doctest-dev` package available in Debian and Ubuntu repositories
was not recently listed in the README.md build instructions for Linux,
but is required. I've added it to the example, as well as switched the
`apt-get` invocations to the canonically-preferred `apt` tool.

I'm a first-time contributor to this project, so I don't know if anyone has
strong opinions on the `apt-get` vs `apt` thing; since the example seems
more oriented towards interactive usage rather than being in a script, I
figured the change might be an apt choice :)

If people *do* think it's unnecessary, I'm more than happy to undo the change.