### PR TITLE
Misc fixes

### DIFF
--- a/include/rellic/AST/IRToASTVisitor.h
+++ b/include/rellic/AST/IRToASTVisitor.h
@@ -61,6 +61,7 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   void visitCmpInst(llvm::CmpInst &inst);
   void visitCastInst(llvm::CastInst &inst);
   void visitSelectInst(llvm::SelectInst &inst);
+  void visitFreezeInst(llvm::FreezeInst &inst);
   void visitPHINode(llvm::PHINode &inst);
 };
 

--- a/include/rellic/AST/Util.h
+++ b/include/rellic/AST/Util.h
@@ -18,6 +18,8 @@ using StmtMap = std::unordered_map<clang::Stmt *, clang::Stmt *>;
 
 bool ReplaceChildren(clang::Stmt *stmt, StmtMap &repl_map);
 
+unsigned GetHash(clang::ASTContext &ctx, clang::Stmt *stmt);
+
 template <typename T>
 size_t GetNumDecls(clang::DeclContext *decl_ctx) {
   size_t result = 0;

--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -165,8 +165,11 @@ clang::Expr *IRToASTVisitor::CreateLiteralExpr(llvm::Constant *constant) {
         auto val_bitwidth{val.getBitWidth()};
         auto ull_bitwidth{ast_ctx.getIntWidth(ast_ctx.LongLongTy)};
         if (val_bitwidth == 1U) {
+          // Booleans
           result = ast.CreateIntLit(val);
         } else if (val_bitwidth > ull_bitwidth) {
+          // Values wider than `long long` will be represented as:
+          // div(val, ULONG_MAX) * ULONG_MAX + rem(val, ULONG_MAX)
           auto umax{llvm::APInt::getMaxValue(ull_bitwidth)};
           auto udiv{val.udiv(umax.zext(val_bitwidth))};
           auto urem{val.urem(umax.zext(val_bitwidth))};

--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -162,8 +162,17 @@ clang::Expr *IRToASTVisitor::CreateLiteralExpr(llvm::Constant *constant) {
       if (llvm::isa<llvm::ConstantInt>(constant)) {
         auto ci{llvm::cast<llvm::ConstantInt>(constant)};
         auto val{ci->getValue()};
-        if (val.getBitWidth() == 1U) {
+        auto val_bitwidth{val.getBitWidth()};
+        auto ull_bitwidth{ast_ctx.getIntWidth(ast_ctx.LongLongTy)};
+        if (val_bitwidth == 1U) {
           result = ast.CreateIntLit(val);
+        } else if (val_bitwidth > ull_bitwidth) {
+          auto umax{llvm::APInt::getMaxValue(ull_bitwidth)};
+          auto udiv{val.udiv(umax.zext(val_bitwidth))};
+          auto urem{val.urem(umax.zext(val_bitwidth))};
+          result = ast.CreateIntLit(umax);
+          result = ast.CreateMul(ast.CreateIntLit(udiv), result);
+          result = ast.CreateAdd(result, ast.CreateIntLit(urem));
         } else {
           result = ast.CreateAdjustedIntLit(val);
         }
@@ -829,9 +838,14 @@ void IRToASTVisitor::visitCastInst(llvm::CastInst &inst) {
       type = ast_ctx.getIntTypeForBitwidth(bitwidth, sign);
     } break;
 
+    case llvm::CastInst::ZExt: {
+      auto bitwidth{ast_ctx.getTypeSize(type)};
+      type = ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/0U);
+    } break;
+
     case llvm::CastInst::SExt: {
       auto bitwidth{ast_ctx.getTypeSize(type)};
-      type = ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/1);
+      type = ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/1U);
     } break;
 
     case llvm::CastInst::AddrSpaceCast:
@@ -844,7 +858,6 @@ void IRToASTVisitor::visitCastInst(llvm::CastInst &inst) {
       // The fallthrough is intentional here
       [[clang::fallthrough]];
 
-    case llvm::CastInst::ZExt:
     case llvm::CastInst::BitCast:
     case llvm::CastInst::PtrToInt:
     case llvm::CastInst::IntToPtr:
@@ -875,6 +888,16 @@ void IRToASTVisitor::visitSelectInst(llvm::SelectInst &inst) {
   auto fval{GetOperandExpr(inst.getFalseValue())};
 
   select = ast.CreateConditional(cond, tval, fval);
+}
+
+void IRToASTVisitor::visitFreezeInst(llvm::FreezeInst &inst) {
+  DLOG(INFO) << "visitFreezeInst: " << LLVMThingToString(&inst);
+  auto &freeze{stmts[&inst]};
+  if (freeze) {
+    return;
+  }
+
+  freeze = GetOperandExpr(inst.getOperand(0U));
 }
 
 void IRToASTVisitor::visitPHINode(llvm::PHINode &inst) {

--- a/lib/AST/Util.cpp
+++ b/lib/AST/Util.cpp
@@ -26,4 +26,10 @@ bool ReplaceChildren(clang::Stmt *stmt, StmtMap &repl_map) {
   return change;
 }
 
+unsigned GetHash(clang::ASTContext &ctx, clang::Stmt *stmt) {
+  llvm::FoldingSetNodeID id;
+  stmt->Profile(id, ctx, /*Canonical=*/true);
+  return id.ComputeHash();
+}
+
 }  // namespace rellic

--- a/lib/AST/Z3ConvVisitor.cpp
+++ b/lib/AST/Z3ConvVisitor.cpp
@@ -405,7 +405,6 @@ bool Z3ConvVisitor::HandleCastExpr(T *c_cast) {
   auto z_dst_sort{z_ctx->bv_sort(dst_ty_size)};
   switch (c_cast->getCastKind()) {
     case clang::CastKind::CK_IntegralCast:
-    case clang::CastKind::CK_NullToPointer:
       z_cast = CreateZ3BitwiseCast(z_sub, src_ty_size, dst_ty_size,
                                    c_src_ty->isSignedIntegerType());
       break;
@@ -414,6 +413,7 @@ bool Z3ConvVisitor::HandleCastExpr(T *c_cast) {
       z_cast = z_ctx->function("PtrToInt", z_src_sort, z_dst_sort)(z_sub);
       break;
 
+    case clang::CastKind::CK_NullToPointer:
     case clang::CastKind::CK_IntegralToPointer: {
       auto c_dst_ty_ptr{reinterpret_cast<uint64_t>(c_dst_ty.getAsOpaquePtr())};
       auto z_dst_ty_ptr{z_ctx->bv_val(c_dst_ty_ptr, 8 * sizeof(void *))};

--- a/lib/AST/Z3ConvVisitor.cpp
+++ b/lib/AST/Z3ConvVisitor.cpp
@@ -14,6 +14,7 @@
 #include <glog/logging.h>
 
 #include "rellic/AST/Compat/ASTContext.h"
+#include "rellic/AST/Util.h"
 
 namespace rellic {
 
@@ -514,9 +515,7 @@ bool Z3ConvVisitor::VisitCallExpr(clang::CallExpr *c_call) {
   }
   z3::expr_vector z_args(*z_ctx);
   // Get call id
-  llvm::FoldingSetNodeID c_call_id;
-  c_call->Profile(c_call_id, *c_ctx, /*Canonical=*/true);
-  z_args.push_back(z_ctx->bv_val(c_call_id.ComputeHash(), /*sz=*/64U));
+  z_args.push_back(z_ctx->bv_val(GetHash(*c_ctx, c_call), /*sz=*/64U));
   // Get callee
   auto z_callee{GetZ3Expr(c_call->getCallee())};
   z_args.push_back(z_callee);


### PR DESCRIPTION
* Changes handling of `NullToPointer` casts to be the same as `IntegralToPointer` in C -> Z3 codegen
* Adds C codegen for `freeze` LLVM IR instruction
* Adds C codegen for `i128` LLVM IR constants