### PR TITLE
Fixes regression on variadic function prototypes

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -377,8 +377,8 @@ void DeclTokenizer::VisitFunctionDecl(clang::FunctionDecl *fdecl) {
         if (fdecl->getNumParams()) {
           proto.push_back(Token::CreateMisc(","));
           SpaceImpl(proto);
+          proto.push_back(Token::CreateMisc("..."));
         }
-        proto.push_back(Token::CreateMisc("..."));
       }
     } else if (fdecl->doesThisDeclarationHaveABody() &&
                !fdecl->hasPrototype()) {

--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -62,7 +62,7 @@ clang::QualType IRToASTVisitor::GetQualType(llvm::Type *type) {
       for (auto param : func->params()) {
         params.push_back(GetQualType(param));
       }
-      auto epi = clang::FunctionProtoType::ExtProtoInfo();
+      auto epi{clang::FunctionProtoType::ExtProtoInfo()};
       epi.Variadic = func->isVarArg();
       result = ast_ctx.getFunctionType(ret, params, epi);
     } break;


### PR DESCRIPTION
Makes the printer add ellipses only when the function prototype has at least one named parameter. This is to adhere to ISO C and resolve recompilation errors.