### PR TITLE
Ian/fix duplicate struct names

### DIFF
--- a/include/rellic/AST/IRToASTVisitor.h
+++ b/include/rellic/AST/IRToASTVisitor.h
@@ -43,6 +43,7 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   StmtToIRMap provenance;
   ArgToTempMap temp_decls;
   size_t num_literal_structs = 0;
+  size_t num_declared_structs = 0;
 
   clang::Expr *GetOperandExpr(llvm::Value *val);
   clang::QualType GetQualType(llvm::Type *type);

--- a/tests/tools/decomp/reg_test_structure_fields.c
+++ b/tests/tools/decomp/reg_test_structure_fields.c
@@ -7,8 +7,5 @@ struct b {
 };
 
 int main(void) {
-	struct b v = {{0}};
-
-	return v.subfield.x;
-
+	struct b a;
 }

--- a/tests/tools/decomp/reg_test_structure_fields.c
+++ b/tests/tools/decomp/reg_test_structure_fields.c
@@ -1,0 +1,14 @@
+struct a {
+	int x;
+};
+
+struct b {
+	struct a subfield;
+};
+
+int main(void) {
+	struct b v = {{0}};
+
+	return v.subfield.x;
+
+}


### PR DESCRIPTION
This PR fixes an issue where using GetNumDecls to provide unique structure names fails. This strategy fails when the field of a structure is also a structure, because the deceleration of the current struct has to be added after the fields, so that the field types are declared. To fix this I added an additional counter for declared structures. 