### PR TITLE
Replace expressions in C AST instead of Z3 AST

### DIFF
--- a/include/rellic/AST/Util.h
+++ b/include/rellic/AST/Util.h
@@ -15,6 +15,11 @@
 namespace rellic {
 
 unsigned GetHash(clang::ASTContext &ctx, clang::Stmt *stmt);
+bool IsEquivalent(clang::ASTContext &ctx, clang::Stmt *a, clang::Stmt *b);
+bool Replace(clang::ASTContext &ctx, clang::Stmt *from, clang::Stmt *to,
+             clang::Stmt **in);
+bool Replace(clang::ASTContext &ctx, clang::Expr *from, clang::Expr *to,
+             clang::Expr **in);
 
 template <typename T>
 size_t GetNumDecls(clang::DeclContext *decl_ctx) {

--- a/include/rellic/AST/Util.h
+++ b/include/rellic/AST/Util.h
@@ -16,10 +16,20 @@ namespace rellic {
 
 unsigned GetHash(clang::ASTContext &ctx, clang::Stmt *stmt);
 bool IsEquivalent(clang::ASTContext &ctx, clang::Stmt *a, clang::Stmt *b);
-bool Replace(clang::ASTContext &ctx, clang::Stmt *from, clang::Stmt *to,
-             clang::Stmt **in);
-bool Replace(clang::ASTContext &ctx, clang::Expr *from, clang::Expr *to,
-             clang::Expr **in);
+template <typename TFrom, typename TTo, typename TIn>
+bool Replace(clang::ASTContext &ctx, TFrom *from, TTo *to, TIn **in) {
+  if (IsEquivalent(ctx, *in, from)) {
+    *in = to;
+    return true;
+  } else {
+    bool changed{false};
+    for (auto child{(*in)->child_begin()}; child != (*in)->child_end();
+         ++child) {
+      changed |= Replace(ctx, from, to, &*child);
+    }
+    return changed;
+  }
+}
 
 template <typename T>
 size_t GetNumDecls(clang::DeclContext *decl_ctx) {

--- a/lib/AST/Util.cpp
+++ b/lib/AST/Util.cpp
@@ -25,6 +25,14 @@ unsigned GetHash(clang::ASTContext &ctx, clang::Stmt *stmt) {
 static bool IsEquivalent(clang::ASTContext &ctx, clang::Stmt *a, clang::Stmt *b,
                          llvm::FoldingSetNodeID &foldingSetA,
                          llvm::FoldingSetNodeID &foldingSetB) {
+  if (a == b) {
+    return true;
+  }
+
+  if (a->getStmtClass() != b->getStmtClass()) {
+    return false;
+  }
+
   foldingSetA.clear();
   foldingSetB.clear();
   a->Profile(foldingSetA, ctx, /*Canonical=*/true);
@@ -32,10 +40,6 @@ static bool IsEquivalent(clang::ASTContext &ctx, clang::Stmt *a, clang::Stmt *b,
 
   if (foldingSetA == foldingSetB) {
     return true;
-  }
-
-  if (a->getStmtClass() != b->getStmtClass()) {
-    return false;
   }
 
   auto child_a{a->child_begin()};

--- a/lib/AST/Util.cpp
+++ b/lib/AST/Util.cpp
@@ -8,22 +8,75 @@
 
 #include "rellic/AST/Util.h"
 
+#include <clang/AST/ASTContext.h>
+#include <clang/AST/Expr.h>
 #include <clang/AST/Stmt.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
 namespace rellic {
 
-// unsigned GetHash(clang::ASTContext &ctx, clang::Stmt *stmt) {
-//   llvm::FoldingSetNodeID id;
-//   stmt->Profile(id, ctx, /*Canonical=*/true);
-//   return id.ComputeHash();
-// }
-
 unsigned GetHash(clang::ASTContext &ctx, clang::Stmt *stmt) {
   llvm::FoldingSetNodeID id;
   stmt->Profile(id, ctx, /*Canonical=*/true);
   return id.ComputeHash();
+}
+
+bool IsEquivalent(clang::ASTContext &ctx, clang::Stmt *a, clang::Stmt *b) {
+  if (GetHash(ctx, a) != GetHash(ctx, b)) {
+    return false;
+  }
+
+  if (a->getStmtClass() != b->getStmtClass()) {
+    return false;
+  }
+
+  auto child_a{a->child_begin()};
+  auto child_b{b->child_begin()};
+  while (true) {
+    bool a_end{child_a == a->child_end()};
+    bool b_end{child_b == b->child_end()};
+    if (a_end ^ b_end) {
+      return false;
+    } else if (a_end && b_end) {
+      return true;
+    } else if (!IsEquivalent(ctx, *child_a, *child_b)) {
+      return false;
+    }
+
+    ++child_a;
+    ++child_b;
+  }
+}
+
+bool Replace(clang::ASTContext &ctx, clang::Stmt *from, clang::Stmt *to,
+             clang::Stmt **in) {
+  if (IsEquivalent(ctx, *in, from)) {
+    *in = to;
+    return true;
+  } else {
+    bool changed{false};
+    for (auto child{(*in)->child_begin()}; child != (*in)->child_end();
+         ++child) {
+      changed |= Replace(ctx, from, to, &*child);
+    }
+    return changed;
+  }
+}
+
+bool Replace(clang::ASTContext &ctx, clang::Expr *from, clang::Expr *to,
+             clang::Expr **in) {
+  if (IsEquivalent(ctx, *in, from)) {
+    *in = to;
+    return true;
+  } else {
+    bool changed{false};
+    for (auto child{(*in)->child_begin()}; child != (*in)->child_end();
+         ++child) {
+      changed |= Replace(ctx, from, to, &*child);
+    }
+    return changed;
+  }
 }
 
 }  // namespace rellic

--- a/lib/AST/Util.cpp
+++ b/lib/AST/Util.cpp
@@ -59,34 +59,4 @@ bool IsEquivalent(clang::ASTContext &ctx, clang::Stmt *a, clang::Stmt *b) {
   return IsEquivalent(ctx, a, b, idA, idB);
 }
 
-bool Replace(clang::ASTContext &ctx, clang::Stmt *from, clang::Stmt *to,
-             clang::Stmt **in) {
-  if (IsEquivalent(ctx, *in, from)) {
-    *in = to;
-    return true;
-  } else {
-    bool changed{false};
-    for (auto child{(*in)->child_begin()}; child != (*in)->child_end();
-         ++child) {
-      changed |= Replace(ctx, from, to, &*child);
-    }
-    return changed;
-  }
-}
-
-bool Replace(clang::ASTContext &ctx, clang::Expr *from, clang::Expr *to,
-             clang::Expr **in) {
-  if (IsEquivalent(ctx, *in, from)) {
-    *in = to;
-    return true;
-  } else {
-    bool changed{false};
-    for (auto child{(*in)->child_begin()}; child != (*in)->child_end();
-         ++child) {
-      changed |= Replace(ctx, from, to, &*child);
-    }
-    return changed;
-  }
-}
-
 }  // namespace rellic

--- a/lib/AST/Z3ConvVisitor.cpp
+++ b/lib/AST/Z3ConvVisitor.cpp
@@ -651,11 +651,13 @@ bool Z3ConvVisitor::VisitBinaryOperator(clang::BinaryOperator *c_op) {
 
     case clang::BO_EQ: {
       CondBoolCast();
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs == rhs);
     } break;
 
     case clang::BO_NE:
       CondBoolCast();
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs != rhs);
       break;
 
@@ -680,22 +682,27 @@ bool Z3ConvVisitor::VisitBinaryOperator(clang::BinaryOperator *c_op) {
       break;
 
     case clang::BO_Rem:
+      CondSizeCast();
       InsertZ3Expr(c_op, z3::srem(lhs, rhs));
       break;
 
     case clang::BO_Add:
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs + rhs);
       break;
 
     case clang::BO_Sub:
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs - rhs);
       break;
 
     case clang::BO_Mul:
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs * rhs);
       break;
 
     case clang::BO_Div:
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs / rhs);
       break;
 

--- a/lib/AST/Z3ConvVisitor.cpp
+++ b/lib/AST/Z3ConvVisitor.cpp
@@ -660,18 +660,22 @@ bool Z3ConvVisitor::VisitBinaryOperator(clang::BinaryOperator *c_op) {
       break;
 
     case clang::BO_GE:
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs >= rhs);
       break;
 
     case clang::BO_GT:
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs > rhs);
       break;
 
     case clang::BO_LE:
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs <= rhs);
       break;
 
     case clang::BO_LT:
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs < rhs);
       break;
 
@@ -697,15 +701,18 @@ bool Z3ConvVisitor::VisitBinaryOperator(clang::BinaryOperator *c_op) {
 
     case clang::BO_And:
       CondBoolToBVCast();
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs & rhs);
       break;
 
     case clang::BO_Or:
       CondBoolToBVCast();
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs | rhs);
       break;
 
     case clang::BO_Xor:
+      CondSizeCast();
       InsertZ3Expr(c_op, lhs ^ rhs);
       break;
 


### PR DESCRIPTION
Using Z3 to substitute expressions as a black box loses all provenance info contained inside.
Substituting C expressions directly avoids this.