### PR TITLE
Use new pass API

### DIFF
--- a/include/rellic/AST/ASTPass.h
+++ b/include/rellic/AST/ASTPass.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022-present, Trail of Bits, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed in accordance with the terms specified in
+ * the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+#include <clang/AST/ASTContext.h>
+#include <clang/Frontend/ASTUnit.h>
+#include <rellic/AST/ASTBuilder.h>
+#include <rellic/AST/Util.h>
+
+#include <atomic>
+#include <memory>
+
+namespace rellic {
+
+class ASTPass {
+  std::atomic_bool stop{false};
+
+ protected:
+  StmtToIRMap& provenance;
+  clang::ASTUnit& ast_unit;
+  clang::ASTContext& ast_ctx;
+  ASTBuilder ast;
+
+  bool changed{false};
+
+  virtual void RunImpl() = 0;
+  virtual void StopImpl() {}
+
+ public:
+  ASTPass(StmtToIRMap& provenance, clang::ASTUnit& ast_unit)
+      : provenance(provenance),
+        ast_unit(ast_unit),
+        ast_ctx(ast_unit.getASTContext()),
+        ast(ast_unit) {}
+  virtual ~ASTPass() = default;
+  virtual void Stop() {
+    stop = true;
+    StopImpl();
+  }
+
+  bool Run() {
+    changed = false;
+    stop = false;
+    RunImpl();
+    return changed;
+  }
+
+  bool Stopped() { return stop; }
+};
+
+class CompositeASTPass : public ASTPass {
+  std::vector<std::unique_ptr<ASTPass>> passes;
+
+ protected:
+  void StopImpl() override {
+    for (auto& pass : passes) {
+      pass->Stop();
+    }
+  }
+
+  void RunImpl() override {
+    for (auto& pass : passes) {
+      if (Stopped()) {
+        break;
+      }
+      changed |= pass->Run();
+    }
+  }
+
+ public:
+  CompositeASTPass(StmtToIRMap& provenance, clang::ASTUnit& ast_unit)
+      : ASTPass(provenance, ast_unit) {}
+  std::vector<std::unique_ptr<ASTPass>>& GetPasses() { return passes; }
+};
+}  // namespace rellic

--- a/include/rellic/AST/CondBasedRefine.h
+++ b/include/rellic/AST/CondBasedRefine.h
@@ -8,9 +8,7 @@
 
 #pragma once
 
-#include <llvm/IR/Module.h>
-#include <llvm/Pass.h>
-
+#include "rellic/AST/ASTPass.h"
 #include "rellic/AST/IRToASTVisitor.h"
 #include "rellic/AST/TransformVisitor.h"
 #include "rellic/AST/Z3ConvVisitor.h"
@@ -35,11 +33,8 @@ namespace rellic {
  *     body_else;
  *   }
  */
-class CondBasedRefine : public llvm::ModulePass,
-                        public TransformVisitor<CondBasedRefine> {
+class CondBasedRefine : public TransformVisitor<CondBasedRefine> {
  private:
-  ASTBuilder ast;
-  clang::ASTContext *ast_ctx;
   std::unique_ptr<z3::context> z3_ctx;
   std::unique_ptr<rellic::Z3ConvVisitor> z3_gen;
 
@@ -53,14 +48,13 @@ class CondBasedRefine : public llvm::ModulePass,
 
   void CreateIfThenElseStmts(IfStmtVec stmts);
 
- public:
-  static char ID;
+ protected:
+  void RunImpl() override;
 
+ public:
   CondBasedRefine(StmtToIRMap &provenance, clang::ASTUnit &unit);
 
   bool VisitCompoundStmt(clang::CompoundStmt *compound);
-
-  bool runOnModule(llvm::Module &module) override;
 };
 
 }  // namespace rellic

--- a/include/rellic/AST/DeadStmtElim.h
+++ b/include/rellic/AST/DeadStmtElim.h
@@ -8,9 +8,7 @@
 
 #pragma once
 
-#include <llvm/IR/Module.h>
-#include <llvm/Pass.h>
-
+#include "rellic/AST/ASTPass.h"
 #include "rellic/AST/IRToASTVisitor.h"
 #include "rellic/AST/TransformVisitor.h"
 
@@ -19,21 +17,15 @@ namespace rellic {
 /*
  * This pass eliminates statements that have no effect
  */
-class DeadStmtElim : public llvm::ModulePass,
-                     public TransformVisitor<DeadStmtElim> {
- private:
-  ASTBuilder ast;
-  clang::ASTContext *ast_ctx;
+class DeadStmtElim : public TransformVisitor<DeadStmtElim> {
+ protected:
+  void RunImpl() override;
 
  public:
-  static char ID;
-
   DeadStmtElim(StmtToIRMap &provenance, clang::ASTUnit &unit);
 
   bool VisitIfStmt(clang::IfStmt *ifstmt);
   bool VisitCompoundStmt(clang::CompoundStmt *compound);
-
-  bool runOnModule(llvm::Module &module) override;
 };
 
 }  // namespace rellic

--- a/include/rellic/AST/ExprCombine.h
+++ b/include/rellic/AST/ExprCombine.h
@@ -8,10 +8,6 @@
 
 #pragma once
 
-#include <llvm/IR/Module.h>
-#include <llvm/Pass.h>
-
-#include "rellic/AST/IRToASTVisitor.h"
 #include "rellic/AST/TransformVisitor.h"
 
 namespace rellic {
@@ -20,14 +16,11 @@ namespace rellic {
  * This pass performs a number of different trasnformations on expressions,
  * like turning *&a into a, or !(a == b) into a != b
  */
-class ExprCombine : public llvm::ModulePass,
-                    public TransformVisitor<ExprCombine> {
- private:
-  clang::ASTUnit &unit;
+class ExprCombine : public TransformVisitor<ExprCombine> {
+ protected:
+  void RunImpl() override;
 
  public:
-  static char ID;
-
   ExprCombine(StmtToIRMap &provenance, clang::ASTUnit &unit);
 
   bool VisitCStyleCastExpr(clang::CStyleCastExpr *cast);
@@ -36,8 +29,6 @@ class ExprCombine : public llvm::ModulePass,
   bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr *expr);
   bool VisitMemberExpr(clang::MemberExpr *expr);
   bool VisitParenExpr(clang::ParenExpr *paren);
-
-  bool runOnModule(llvm::Module &module) override;
 };
 
 }  // namespace rellic

--- a/include/rellic/AST/IRToASTVisitor.h
+++ b/include/rellic/AST/IRToASTVisitor.h
@@ -36,11 +36,11 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
 
   ASTBuilder ast;
 
-  IRToTypeDeclMap type_decls;
-  IRToValDeclMap value_decls;
-  IRToStmtMap stmts;
-  StmtToIRMap provenance;
-  ArgToTempMap temp_decls;
+  IRToTypeDeclMap &type_decls;
+  IRToValDeclMap &value_decls;
+  IRToStmtMap &stmts;
+  StmtToIRMap &provenance;
+  ArgToTempMap &temp_decls;
   size_t num_literal_structs = 0;
   size_t num_declared_structs = 0;
 
@@ -52,7 +52,9 @@ class IRToASTVisitor : public llvm::InstVisitor<IRToASTVisitor> {
   clang::Decl *GetOrCreateIntrinsic(llvm::InlineAsm *val);
 
  public:
-  IRToASTVisitor(clang::ASTUnit &unit);
+  IRToASTVisitor(StmtToIRMap &provenance, clang::ASTUnit &unit,
+                 IRToTypeDeclMap &type_decls, IRToValDeclMap &value_decls,
+                 IRToStmtMap &stmts, ArgToTempMap &temp_decls);
 
   clang::Stmt *GetOrCreateStmt(llvm::Value *val);
   clang::Decl *GetOrCreateDecl(llvm::Value *val);

--- a/include/rellic/AST/LocalDeclRenamer.h
+++ b/include/rellic/AST/LocalDeclRenamer.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <llvm/Pass.h>
-
 #include <unordered_map>
 #include <unordered_set>
 
@@ -21,12 +19,8 @@ namespace rellic {
 
 using ValDeclToIRMap = std::unordered_map<clang::ValueDecl *, llvm::Value *>;
 
-class LocalDeclRenamer : public llvm::ModulePass,
-                         public TransformVisitor<LocalDeclRenamer> {
+class LocalDeclRenamer : public TransformVisitor<LocalDeclRenamer> {
  private:
-  ASTBuilder ast;
-  clang::ASTContext *ast_ctx;
-
   ValDeclToIRMap decls;
 
   // Stores currently visible names, with scope awareness
@@ -38,17 +32,16 @@ class LocalDeclRenamer : public llvm::ModulePass,
 
   bool IsNameVisible(const std::string &name);
 
- public:
-  static char ID;
+ protected:
+  void RunImpl() override;
 
+ public:
   LocalDeclRenamer(StmtToIRMap &provenance, clang::ASTUnit &unit,
                    IRToNameMap &names, IRToValDeclMap &decls);
 
   bool shouldTraversePostOrder() override;
   bool VisitVarDecl(clang::VarDecl *decl);
   bool TraverseFunctionDecl(clang::FunctionDecl *decl);
-
-  bool runOnModule(llvm::Module &module) override;
 };
 
 }  // namespace rellic

--- a/include/rellic/AST/LoopRefine.h
+++ b/include/rellic/AST/LoopRefine.h
@@ -8,10 +8,6 @@
 
 #pragma once
 
-#include <llvm/IR/Module.h>
-#include <llvm/Pass.h>
-
-#include "rellic/AST/IRToASTVisitor.h"
 #include "rellic/AST/TransformVisitor.h"
 
 namespace rellic {
@@ -33,19 +29,14 @@ namespace rellic {
  *     body;
  *   }
  */
-class LoopRefine : public llvm::ModulePass,
-                   public TransformVisitor<LoopRefine> {
- private:
-  clang::ASTUnit &unit;
+class LoopRefine : public TransformVisitor<LoopRefine> {
+ protected:
+  void RunImpl() override;
 
  public:
-  static char ID;
-
   LoopRefine(StmtToIRMap &provenance, clang::ASTUnit &unit);
 
   bool VisitWhileStmt(clang::WhileStmt *loop);
-
-  bool runOnModule(llvm::Module &module) override;
 };
 
 }  // namespace rellic

--- a/include/rellic/AST/NestedCondProp.h
+++ b/include/rellic/AST/NestedCondProp.h
@@ -9,12 +9,8 @@
 #pragma once
 
 #include <clang/AST/RecursiveASTVisitor.h>
-#include <llvm/IR/Module.h>
-#include <llvm/Pass.h>
 #include <z3++.h>
 
-#include "rellic/AST/ASTBuilder.h"
-#include "rellic/AST/IRToASTVisitor.h"
 #include "rellic/AST/TransformVisitor.h"
 #include "rellic/AST/Z3ConvVisitor.h"
 
@@ -38,28 +34,23 @@ namespace rellic {
  *     }
  *   }
  */
-class NestedCondProp : public llvm::ModulePass,
-                       public TransformVisitor<NestedCondProp> {
+class NestedCondProp : public TransformVisitor<NestedCondProp> {
  private:
-  ASTBuilder ast;
-  clang::ASTContext *ast_ctx;
-
   std::unique_ptr<z3::context> z3_ctx;
   std::unique_ptr<rellic::Z3ConvVisitor> z3_gen;
 
   std::unordered_map<clang::Stmt *, clang::Expr *> parent_conds;
 
- public:
-  static char ID;
+ protected:
+  void RunImpl() override;
 
+ public:
   bool shouldTraversePostOrder() override { return false; }
 
   NestedCondProp(StmtToIRMap &provenance, clang::ASTUnit &unit);
 
   bool VisitIfStmt(clang::IfStmt *stmt);
   bool VisitWhileStmt(clang::WhileStmt *stmt);
-
-  bool runOnModule(llvm::Module &module) override;
 };
 
 }  // namespace rellic

--- a/include/rellic/AST/NestedScopeCombine.h
+++ b/include/rellic/AST/NestedScopeCombine.h
@@ -8,10 +8,6 @@
 
 #pragma once
 
-#include <llvm/IR/Module.h>
-#include <llvm/Pass.h>
-
-#include "rellic/AST/IRToASTVisitor.h"
 #include "rellic/AST/TransformVisitor.h"
 
 namespace rellic {
@@ -34,21 +30,15 @@ namespace rellic {
  *
  *   body1;
  */
-class NestedScopeCombine : public llvm::ModulePass,
-                           public TransformVisitor<NestedScopeCombine> {
- private:
-  ASTBuilder ast;
-  clang::ASTContext *ast_ctx;
+class NestedScopeCombine : public TransformVisitor<NestedScopeCombine> {
+ protected:
+  void RunImpl() override;
 
  public:
-  static char ID;
-
   NestedScopeCombine(StmtToIRMap &provenance, clang::ASTUnit &unit);
 
   bool VisitIfStmt(clang::IfStmt *ifstmt);
   bool VisitCompoundStmt(clang::CompoundStmt *compound);
-
-  bool runOnModule(llvm::Module &module) override;
 };
 
 }  // namespace rellic

--- a/include/rellic/AST/NormalizeCond.h
+++ b/include/rellic/AST/NormalizeCond.h
@@ -8,10 +8,6 @@
 
 #pragma once
 
-#include <llvm/IR/Module.h>
-#include <llvm/Pass.h>
-
-#include "rellic/AST/IRToASTVisitor.h"
 #include "rellic/AST/TransformVisitor.h"
 
 namespace rellic {
@@ -21,10 +17,9 @@ namespace rellic {
  * has the potential of creating an exponential number of terms, so it's best to
  * perform this pass after simplification.
  */
-class NormalizeCond : public llvm::ModulePass,
-                      public TransformVisitor<NormalizeCond> {
- private:
-  clang::ASTUnit &unit;
+class NormalizeCond : public TransformVisitor<NormalizeCond> {
+ protected:
+  void RunImpl() override;
 
  public:
   static char ID;
@@ -33,8 +28,6 @@ class NormalizeCond : public llvm::ModulePass,
 
   bool VisitUnaryOperator(clang::UnaryOperator *op);
   bool VisitBinaryOperator(clang::BinaryOperator *op);
-
-  bool runOnModule(llvm::Module &module) override;
 };
 
 }  // namespace rellic

--- a/include/rellic/AST/ReachBasedRefine.h
+++ b/include/rellic/AST/ReachBasedRefine.h
@@ -8,10 +8,6 @@
 
 #pragma once
 
-#include <llvm/IR/Module.h>
-#include <llvm/Pass.h>
-
-#include "rellic/AST/IRToASTVisitor.h"
 #include "rellic/AST/TransformVisitor.h"
 #include "rellic/AST/Z3ConvVisitor.h"
 
@@ -40,12 +36,8 @@ namespace rellic {
  *     body3;
  *   }
  */
-class ReachBasedRefine : public llvm::ModulePass,
-                         public TransformVisitor<ReachBasedRefine> {
+class ReachBasedRefine : public TransformVisitor<ReachBasedRefine> {
  private:
-  ASTBuilder ast;
-  clang::ASTContext *ast_ctx;
-
   std::unique_ptr<z3::context> z3_ctx;
   std::unique_ptr<rellic::Z3ConvVisitor> z3_gen;
 
@@ -59,14 +51,13 @@ class ReachBasedRefine : public llvm::ModulePass,
 
   void CreateIfElseStmts(IfStmtVec stmts);
 
- public:
-  static char ID;
+ protected:
+  void RunImpl() override;
 
+ public:
   ReachBasedRefine(StmtToIRMap &provenance, clang::ASTUnit &unit);
 
   bool VisitCompoundStmt(clang::CompoundStmt *compound);
-
-  bool runOnModule(llvm::Module &module) override;
 };
 
 }  // namespace rellic

--- a/include/rellic/AST/StructFieldRenamer.h
+++ b/include/rellic/AST/StructFieldRenamer.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <llvm/Pass.h>
-
 #include <unordered_map>
 
 #include "rellic/AST/DebugInfoCollector.h"
@@ -20,25 +18,22 @@ namespace rellic {
 
 using TypeDeclToIRMap = std::unordered_map<clang::TypeDecl *, llvm::Type *>;
 
-class StructFieldRenamer : public llvm::ModulePass,
-                           public TransformVisitor<StructFieldRenamer> {
+class StructFieldRenamer
+    : public ASTPass,
+      public clang::RecursiveASTVisitor<StructFieldRenamer> {
  private:
-  ASTBuilder ast;
-  clang::ASTContext *ast_ctx;
-
   TypeDeclToIRMap decls;
   IRTypeToDITypeMap &types;
   IRToTypeDeclMap &inv_decl;
 
- public:
-  static char ID;
+ protected:
+  void RunImpl() override;
 
+ public:
   StructFieldRenamer(StmtToIRMap &provenance, clang::ASTUnit &unit,
                      IRTypeToDITypeMap &types, IRToTypeDeclMap &decls);
 
   bool VisitRecordDecl(clang::RecordDecl *decl);
-
-  bool runOnModule(llvm::Module &module) override;
 };
 
 }  // namespace rellic

--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -23,8 +23,17 @@
 
 namespace rellic {
 
-IRToASTVisitor::IRToASTVisitor(clang::ASTUnit &unit)
-    : ast_ctx(unit.getASTContext()), ast(unit) {}
+IRToASTVisitor::IRToASTVisitor(StmtToIRMap &provenance, clang::ASTUnit &unit,
+                               IRToTypeDeclMap &type_decls,
+                               IRToValDeclMap &value_decls, IRToStmtMap &stmts,
+                               ArgToTempMap &temp_decls)
+    : provenance(provenance),
+      ast_ctx(unit.getASTContext()),
+      ast(unit),
+      type_decls(type_decls),
+      value_decls(value_decls),
+      stmts(stmts),
+      temp_decls(temp_decls) {}
 
 clang::QualType IRToASTVisitor::GetQualType(llvm::Type *type) {
   DLOG(INFO) << "GetQualType: " << LLVMThingToString(type);

--- a/lib/AST/ReachBasedRefine.cpp
+++ b/lib/AST/ReachBasedRefine.cpp
@@ -29,14 +29,9 @@ static IfStmtVec GetIfStmts(clang::CompoundStmt *compound) {
 
 }  // namespace
 
-char ReachBasedRefine::ID = 0;
-
 ReachBasedRefine::ReachBasedRefine(StmtToIRMap &provenance,
                                    clang::ASTUnit &unit)
-    : ModulePass(ReachBasedRefine::ID),
-      TransformVisitor<ReachBasedRefine>(provenance),
-      ast(unit),
-      ast_ctx(&unit.getASTContext()),
+    : TransformVisitor<ReachBasedRefine>(provenance, unit),
       z3_ctx(new z3::context()),
       z3_gen(new rellic::Z3ConvVisitor(unit, z3_ctx.get())),
       z3_solver(*z3_ctx, "sat") {}
@@ -134,11 +129,10 @@ bool ReachBasedRefine::VisitCompoundStmt(clang::CompoundStmt *compound) {
   return true;
 }
 
-bool ReachBasedRefine::runOnModule(llvm::Module &module) {
+void ReachBasedRefine::RunImpl() {
   LOG(INFO) << "Reachability-based refinement";
-  Initialize();
-  TraverseDecl(ast_ctx->getTranslationUnitDecl());
-  return changed;
+  TransformVisitor<ReachBasedRefine>::RunImpl();
+  TraverseDecl(ast_ctx.getTranslationUnitDecl());
 }
 
 }  // namespace rellic

--- a/lib/Decompiler.cpp
+++ b/lib/Decompiler.cpp
@@ -91,11 +91,11 @@ static void RemovePHINodes(llvm::Module& module) {
 
 static void LowerSwitches(llvm::Module& module) {
   llvm::PassBuilder pb;
-  llvm::ModulePassManager mpm(false);
-  llvm::ModuleAnalysisManager mam(false);
-  llvm::LoopAnalysisManager lam(false);
-  llvm::CGSCCAnalysisManager cam(false);
-  llvm::FunctionAnalysisManager fam(false);
+  llvm::ModulePassManager mpm;
+  llvm::ModuleAnalysisManager mam;
+  llvm::LoopAnalysisManager lam;
+  llvm::CGSCCAnalysisManager cam;
+  llvm::FunctionAnalysisManager fam;
 
   pb.registerFunctionAnalyses(fam);
   pb.registerModuleAnalyses(mam);

--- a/tools/repl/Repl.cpp
+++ b/tools/repl/Repl.cpp
@@ -272,11 +272,11 @@ static void do_apply(std::istream& is) {
   } else if (what == "lower-switches") {
     Diff d{[](llvm::raw_ostream& os) { module->print(os, nullptr); }};
     llvm::PassBuilder pb;
-    llvm::ModulePassManager mpm(false);
-    llvm::ModuleAnalysisManager mam(false);
-    llvm::LoopAnalysisManager lam(false);
-    llvm::CGSCCAnalysisManager cam(false);
-    llvm::FunctionAnalysisManager fam(false);
+    llvm::ModulePassManager mpm;
+    llvm::ModuleAnalysisManager mam;
+    llvm::LoopAnalysisManager lam;
+    llvm::CGSCCAnalysisManager cam;
+    llvm::FunctionAnalysisManager fam;
 
     pb.registerFunctionAnalyses(fam);
     pb.registerModuleAnalyses(mam);


### PR DESCRIPTION
Removes usage of the legacy LLVM pass managers.

Also introduces a new API for AST passes, which are designed to be interruptible and not own the data they manipulate, e.g. they don't take ownership of provenance info. This is to simplify management of resources in interactive settings.