### PR TITLE
Use different approach for handling array stores

### DIFF
--- a/include/rellic/BC/Util.h
+++ b/include/rellic/BC/Util.h
@@ -52,7 +52,5 @@ void LowerSwitches(llvm::Module &module);
 
 void RemoveInsertValues(llvm::Module &module);
 
-void ConvertArrayStores(llvm::Module &module);
-
 void ConvertArrayArguments(llvm::Module &module);
 }  // namespace rellic

--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -799,15 +799,32 @@ void IRToASTVisitor::visitStoreInst(llvm::StoreInst &inst) {
   // Get the operand we're assigning to
   auto lhs{GetOperandExpr(inst.getPointerOperand())};
   // Get the operand we're assigning from
-  if (auto undef = llvm::dyn_cast<llvm::UndefValue>(inst.getValueOperand())) {
+  auto value_opnd{inst.getValueOperand()};
+  if (auto undef = llvm::dyn_cast<llvm::UndefValue>(value_opnd)) {
     DLOG(INFO) << "Invalid store ignored: " << LLVMThingToString(&inst);
     return;
   }
-  auto rhs{GetOperandExpr(inst.getValueOperand())};
-  // Create the assignemnt itself
-  auto deref{ast.CreateDeref(lhs)};
-  CopyProvenance(lhs, deref, provenance);
-  assign = ast.CreateAssign(deref, rhs);
+  auto rhs{GetOperandExpr(value_opnd)};
+  if (value_opnd->getType()->isArrayTy()) {
+    // We cannot directly assign arrays, so we generate memcpy or memset instead
+    auto DL{inst.getModule()->getDataLayout()};
+    llvm::APInt sz(64, DL.getTypeAllocSize(value_opnd->getType()));
+    auto sz_expr{ast.CreateIntLit(sz)};
+    if (llvm::isa<llvm::ConstantAggregateZero>(value_opnd)) {
+      llvm::APInt zero(8, 0, false);
+      std::vector<clang::Expr *> args{lhs, ast.CreateIntLit(zero), sz_expr};
+      assign = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memset, args);
+    } else {
+      llvm::APInt zero(8, 0, false);
+      std::vector<clang::Expr *> args{lhs, rhs, sz_expr};
+      assign = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy, args);
+    }
+  } else {
+    // Create the assignemnt itself
+    auto deref{ast.CreateDeref(lhs)};
+    CopyProvenance(lhs, deref, provenance);
+    assign = ast.CreateAssign(deref, rhs);
+  }
 }
 
 void IRToASTVisitor::visitLoadInst(llvm::LoadInst &inst) {

--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -815,7 +815,6 @@ void IRToASTVisitor::visitStoreInst(llvm::StoreInst &inst) {
       std::vector<clang::Expr *> args{lhs, ast.CreateIntLit(zero), sz_expr};
       assign = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memset, args);
     } else {
-      llvm::APInt zero(8, 0, false);
       std::vector<clang::Expr *> args{lhs, rhs, sz_expr};
       assign = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy, args);
     }

--- a/lib/BC/Util.cpp
+++ b/lib/BC/Util.cpp
@@ -212,6 +212,7 @@ void LowerSwitches(llvm::Module &module) {
   fam.clear();
   cam.clear();
   lam.clear();
+  CHECK(VerifyModule(&module)) << "Transformation broke module correctness";
 }
 
 // Takes an insertvalue node and converts into an alloca, store, load sequence
@@ -269,87 +270,8 @@ void RemoveInsertValues(llvm::Module &m) {
     auto new_load{ConvertInsertValue(iv)};
     CloneMetadataInto(new_load, mds);
   }
-}
 
-static llvm::Instruction *ConvertArrayStore(llvm::StoreInst *I) {
-  auto m{I->getModule()};
-  auto &ctx{m->getContext()};
-  auto DL{m->getDataLayout()};
-
-  auto src_opnd{I->getValueOperand()};
-  auto dst_opnd{I->getPointerOperand()};
-
-  auto sz{llvm::ConstantInt::get(
-      ctx, llvm::APInt(64, DL.getTypeAllocSize(src_opnd->getType()), false))};
-
-  if (llvm::isa<llvm::ConstantAggregateZero>(src_opnd)) {
-    // Convert `store [ ... ] zeroinit, ...` to a memset call
-    llvm::Type *params[2];
-    params[0] = llvm::Type::getInt8PtrTy(ctx);
-    params[1] = llvm::Type::getInt64Ty(ctx);
-
-    auto decl{llvm::Intrinsic::getDeclaration(m, llvm::Intrinsic::memset,
-                                              {params, 2})};
-
-    llvm::Value *args[4];
-    args[0] = llvm::CastInst::Create(llvm::Instruction::BitCast, dst_opnd,
-                                     llvm::Type::getInt8PtrTy(ctx), "", I);
-    args[1] = llvm::ConstantInt::get(ctx, llvm::APInt(8, 0, false));
-    args[2] = sz;
-    args[3] = llvm::ConstantInt::getFalse(ctx);
-
-    auto res{llvm::CallInst::Create(decl->getFunctionType(), decl, {args, 4},
-                                    "", I)};
-    I->eraseFromParent();
-    return res;
-  } else {
-    // Convert `store [ ... ], ...` to a memcpy call
-    llvm::Type *params[3];
-    params[0] = llvm::Type::getInt8PtrTy(ctx);
-    params[1] = params[0];
-    params[2] = llvm::Type::getInt64Ty(ctx);
-
-    auto decl{llvm::Intrinsic::getDeclaration(m, llvm::Intrinsic::memcpy,
-                                              {params, 3})};
-
-    llvm::Value *args[4];
-
-    std::vector<llvm::Value *> gep_indices{
-        llvm::ConstantInt::get(ctx, llvm::APInt(64, 0, false))};
-    auto src_ptr{llvm::GetElementPtrInst::Create(src_opnd->getType(), src_opnd,
-                                                 gep_indices, "", I)};
-    args[0] = llvm::CastInst::Create(llvm::Instruction::BitCast, src_ptr,
-                                     llvm::Type::getInt8PtrTy(ctx), "", I);
-    args[1] = llvm::CastInst::Create(llvm::Instruction::BitCast, dst_opnd,
-                                     llvm::Type::getInt8PtrTy(ctx), "", I);
-    args[2] = sz;
-    args[3] = llvm::ConstantInt::getFalse(ctx);
-
-    auto res{llvm::CallInst::Create(decl->getFunctionType(), decl, {args, 4},
-                                    "", I)};
-    I->eraseFromParent();
-    return res;
-  }
-}
-
-void ConvertArrayStores(llvm::Module &m) {
-  std::vector<llvm::StoreInst *> work_list;
-  for (auto &func : m) {
-    for (auto &inst : llvm::instructions(func)) {
-      if (auto store = llvm::dyn_cast<llvm::StoreInst>(&inst)) {
-        if (store->getValueOperand()->getType()->isArrayTy()) {
-          work_list.push_back(store);
-        }
-      }
-    }
-  }
-
-  for (auto iv : work_list) {
-    llvm::SmallVector<std::pair<unsigned, llvm::MDNode *>, 16u> mds;
-    iv->getAllMetadataOtherThanDebugLoc(mds);
-    auto new_inst{ConvertArrayStore(iv)};
-    CloneMetadataInto(new_inst, mds);
-  }
+  CHECK(VerifyModule(&m)) << "Transformation broke module correctness";
 }
 
 void ConvertArrayArguments(llvm::Module &m) {
@@ -483,6 +405,8 @@ void ConvertArrayArguments(llvm::Module &m) {
       func->eraseFromParent();
     }
   }
+
+  CHECK(VerifyModule(&m)) << "Transformation broke module correctness";
 }
 
 }  // namespace rellic

--- a/lib/Decompiler.cpp
+++ b/lib/Decompiler.cpp
@@ -86,7 +86,6 @@ Result<DecompilationResult, DecompilationError> Decompile(
 
     ConvertArrayArguments(*module);
     RemoveInsertValues(*module);
-    ConvertArrayStores(*module);
 
     InitOptPasses();
     rellic::DebugInfoCollector dic;


### PR DESCRIPTION
Patching the bitcode to remove array stores had the potential for creating invalid modules.
Handling the stores in the codegen phase fixes the issue.

(Sprinkled some validation after each IR pass for good measure)