### PR TITLE
Bump httplib to v0.10.6

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -51,7 +51,7 @@ set(RELLIC_HEADERGEN "${RELLIC_HEADERGEN}" PARENT_SCOPE)
 include(FetchContent)
 FetchContent_Declare(httplib
   GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-  GIT_TAG        bb00a23116f5c9f64f1e257ecf5b97a49d0be44e
+  GIT_TAG        d87abeecf0ca2bd2899140208523413bef6fc523
 )
 FetchContent_MakeAvailable(httplib)
 


### PR DESCRIPTION
The old version breaks on the new OpenSSL version(s).

This dependency should be managed by cxx-common instead of the FetchContent call. I am adding the `cpp-httplib` port to cxx-common for the next release, at which point we can make the conversion to use `find_package`.

See https://github.com/lifting-bits/cxx-common/pull/935