### PR TITLE
Fix bug in reaching conditions generation

### DIFF
--- a/include/rellic/AST/CondBasedRefine.h
+++ b/include/rellic/AST/CondBasedRefine.h
@@ -42,8 +42,6 @@ class CondBasedRefine : public TransformVisitor<CondBasedRefine> {
 
   z3::expr GetZ3Cond(clang::IfStmt *ifstmt);
 
-  bool Prove(z3::expr expr);
-
   using IfStmtVec = std::vector<clang::IfStmt *>;
 
   void CreateIfThenElseStmts(IfStmtVec stmts);

--- a/include/rellic/AST/GenerateAST.h
+++ b/include/rellic/AST/GenerateAST.h
@@ -47,6 +47,7 @@ class GenerateAST : public llvm::AnalysisInfoMixin<GenerateAST> {
 
   std::map<BBEdge, unsigned> z_edges;
   std::unordered_map<llvm::BasicBlock *, unsigned> reaching_conds;
+  bool reaching_conds_changed{true};
   std::unordered_map<llvm::BasicBlock *, clang::IfStmt *> block_stmts;
   std::unordered_map<llvm::Region *, clang::CompoundStmt *> region_stmts;
 
@@ -61,7 +62,8 @@ class GenerateAST : public llvm::AnalysisInfoMixin<GenerateAST> {
                                     llvm::ConstantInt *c);
 
   z3::expr GetOrCreateEdgeCond(llvm::BasicBlock *from, llvm::BasicBlock *to);
-  z3::expr GetOrCreateReachingCond(llvm::BasicBlock *block);
+  z3::expr GetReachingCond(llvm::BasicBlock *block);
+  void CreateReachingCond(llvm::BasicBlock *block);
 
   clang::Expr *ConvertExpr(z3::expr expr);
 

--- a/include/rellic/AST/ReachBasedRefine.h
+++ b/include/rellic/AST/ReachBasedRefine.h
@@ -41,11 +41,7 @@ class ReachBasedRefine : public TransformVisitor<ReachBasedRefine> {
   std::unique_ptr<z3::context> z3_ctx;
   std::unique_ptr<rellic::Z3ConvVisitor> z3_gen;
 
-  z3::tactic z3_solver;
-
   z3::expr GetZ3Cond(clang::IfStmt *ifstmt);
-
-  bool Prove(z3::expr expr);
 
   using IfStmtVec = std::vector<clang::IfStmt *>;
 

--- a/include/rellic/AST/Util.h
+++ b/include/rellic/AST/Util.h
@@ -12,6 +12,7 @@
 #include <clang/AST/Stmt.h>
 #include <clang/Frontend/ASTUnit.h>
 #include <llvm/IR/Value.h>
+#include <z3++.h>
 
 #include <unordered_map>
 
@@ -74,5 +75,9 @@ clang::Expr *Clone(clang::ASTUnit &unit, clang::Expr *stmt,
                    ExprToUseMap &provenance);
 
 std::string ClangThingToString(clang::Stmt *stmt);
+
+z3::goal ApplyTactic(z3::context &ctx, const z3::tactic &tactic, z3::expr expr);
+
+bool Prove(z3::context &ctx, z3::expr expr);
 
 }  // namespace rellic

--- a/include/rellic/AST/Z3CondSimplify.h
+++ b/include/rellic/AST/Z3CondSimplify.h
@@ -25,9 +25,6 @@ class Z3CondSimplify : public TransformVisitor<Z3CondSimplify> {
   std::unique_ptr<z3::context> z_ctx;
   std::unique_ptr<rellic::Z3ConvVisitor> z_gen;
 
-  z3::tactic tactic;
-
-  bool Prove(z3::expr e);
   z3::expr ToZ3(clang::Expr *e);
 
   std::unordered_map<clang::Expr *, unsigned> hashes;
@@ -67,8 +64,6 @@ class Z3CondSimplify : public TransformVisitor<Z3CondSimplify> {
   Z3CondSimplify(Provenance &provenance, clang::ASTUnit &unit);
 
   z3::context &GetZ3Context() { return *z_ctx; }
-
-  void SetZ3Tactic(z3::tactic t) { tactic = t; };
 
   bool VisitIfStmt(clang::IfStmt *stmt);
   bool VisitWhileStmt(clang::WhileStmt *loop);

--- a/include/rellic/Decompiler.h
+++ b/include/rellic/Decompiler.h
@@ -24,7 +24,6 @@ struct DecompilationOptions {
   bool dead_stmt_elimination = true;
   struct {
     bool z3_cond_simplify = true;
-    std::vector<std::string> z3_tactics{"sat"};
     bool nested_cond_propagate = true;
     bool nested_scope_combine = true;
     bool cond_base_refine = true;
@@ -38,7 +37,6 @@ struct DecompilationOptions {
   } loop_refinement;
   struct {
     bool z3_cond_simplify = true;
-    std::vector<std::string> z3_tactics{"sat"};
     bool nested_cond_propagate = true;
     bool nested_scope_combine = true;
     bool expression_normalize = false;

--- a/lib/AST/GenerateAST.cpp
+++ b/lib/AST/GenerateAST.cpp
@@ -252,8 +252,8 @@ void GenerateAST::CreateReachingCond(llvm::BasicBlock *block) {
 
     z3::tactic aig(*z_ctx, "aig");
     z3::tactic simplify(*z_ctx, "simplify");
-    z3::tactic ctx_solver_simplify(*z_ctx, "ctx-solver-simplify");
-    auto tactic{simplify & aig & ctx_solver_simplify};
+    z3::tactic solve_eqs(*z_ctx, "solve-eqs");
+    auto tactic{simplify & aig & solve_eqs};
     return ApplyTactic(*z_ctx, tactic, expr).as_expr();
   }};
 

--- a/lib/AST/GenerateAST.cpp
+++ b/lib/AST/GenerateAST.cpp
@@ -252,8 +252,8 @@ void GenerateAST::CreateReachingCond(llvm::BasicBlock *block) {
 
     z3::tactic aig(*z_ctx, "aig");
     z3::tactic simplify(*z_ctx, "simplify");
-    z3::tactic solve_eqs(*z_ctx, "solve-eqs");
-    auto tactic{simplify & aig & solve_eqs};
+    z3::tactic ctx_solver_simplify(*z_ctx, "ctx-solver-simplify");
+    auto tactic{simplify & aig & ctx_solver_simplify};
     return ApplyTactic(*z_ctx, tactic, expr).as_expr();
   }};
 

--- a/lib/AST/GenerateAST.cpp
+++ b/lib/AST/GenerateAST.cpp
@@ -236,36 +236,68 @@ z3::expr GenerateAST::GetOrCreateEdgeCond(llvm::BasicBlock *from,
   return z_exprs[z_edges[{from, to}]];
 }
 
-z3::expr GenerateAST::GetOrCreateReachingCond(llvm::BasicBlock *block) {
+z3::expr GenerateAST::GetReachingCond(llvm::BasicBlock *block) {
   if (reaching_conds.find(block) == reaching_conds.end()) {
-    if (block->hasNPredecessorsOrMore(1)) {
-      auto cond{z_ctx->bool_val(false)};
-      // Gather reaching conditions from predecessors of the block
-      for (auto pred : llvm::predecessors(block)) {
-        auto has_pred_cond{reaching_conds.find(pred) != reaching_conds.end()};
-        auto edge_cond{GetOrCreateEdgeCond(pred, block)};
-        // Construct reaching condition from `pred` to `block` as
-        // `reach_cond[pred] && edge_cond(pred, block)` or one of
-        // the two if the other one is missing.
-        auto conj_cond{has_pred_cond
-                           ? (z_exprs[reaching_conds[pred]] && edge_cond)
-                           : edge_cond};
-        // Append `conj_cond` to reaching conditions of other
-        // predecessors via an `||`. Use `conj_cond` if there
-        // is no `cond` yet.
-        cond = cond || conj_cond;
-      }
-
-      reaching_conds[block] = z_exprs.size();
-      z_exprs.push_back(cond.simplify());
-    } else {
-      auto cond{z_ctx->bool_val(true)};
-      reaching_conds[block] = z_exprs.size();
-      z_exprs.push_back(cond);
-    }
+    return z_ctx->bool_val(false);
   }
 
   return z_exprs[reaching_conds[block]];
+}
+
+void GenerateAST::CreateReachingCond(llvm::BasicBlock *block) {
+  auto Prove{[this](z3::expr expr) {
+    z3::goal goal(*z_ctx);
+    goal.add((!expr).simplify());
+    auto app{z3::tactic(*z_ctx, "sat").apply(goal)};
+    CHECK(app.size() == 1) << "Unexpected multiple goals in application!";
+    return app[0].is_decided_unsat();
+  }};
+
+  auto Simplify{[this, &Prove](z3::expr expr) {
+    if (Prove(expr)) {
+      return z_ctx->bool_val(true);
+    }
+
+    z3::tactic aig(*z_ctx, "aig");
+    z3::tactic simplify(*z_ctx, "simplify");
+    z3::tactic ctx_solver_simplify(*z_ctx, "ctx-solver-simplify");
+    auto tactic{simplify & aig & ctx_solver_simplify};
+    z3::goal goal(*z_ctx);
+    goal.add(expr);
+    auto app{tactic.apply(goal)};
+    CHECK(app.size() == 1) << "Unexpected multiple goals in application!";
+    return app[0].as_expr();
+  }};
+
+  auto old_cond{GetReachingCond(block)};
+  if (block->hasNPredecessorsOrMore(1)) {
+    // Gather reaching conditions from predecessors of the block
+    auto cond{z_ctx->bool_val(false)};
+    for (auto pred : llvm::predecessors(block)) {
+      auto pred_cond{GetReachingCond(pred)};
+      auto edge_cond{GetOrCreateEdgeCond(pred, block)};
+      // Construct reaching condition from `pred` to `block` as
+      // `reach_cond[pred] && edge_cond(pred, block)` or one of
+      // the two if the other one is missing.
+      auto conj_cond{Simplify(pred_cond && edge_cond)};
+      // Append `conj_cond` to reaching conditions of other
+      // predecessors via an `||`. Use `conj_cond` if there
+      // is no `cond` yet.
+      cond = Simplify(cond || conj_cond);
+    }
+
+    if (!Prove(old_cond == cond)) {
+      reaching_conds[block] = z_exprs.size();
+      z_exprs.push_back(cond);
+      reaching_conds_changed = true;
+    }
+  } else {
+    if (reaching_conds.find(block) == reaching_conds.end()) {
+      reaching_conds[block] = z_exprs.size();
+      z_exprs.push_back(z_ctx->bool_val(true));
+      reaching_conds_changed = true;
+    }
+  }
 }
 
 StmtVec GenerateAST::CreateBasicBlockStmts(llvm::BasicBlock *block) {
@@ -351,7 +383,7 @@ StmtVec GenerateAST::CreateRegionStmts(llvm::Region *region) {
       compound = ast.CreateCompoundStmt(block_body);
     }
     // Gate the compound behind a reaching condition
-    auto z_expr{GetOrCreateReachingCond(block)};
+    auto z_expr{GetReachingCond(block)};
     block_stmts[block] = ast.CreateIf(ConvertExpr(z_expr), compound);
     // Store the compound
     result.push_back(block_stmts[block]);
@@ -454,7 +486,7 @@ clang::CompoundStmt *GenerateAST::StructureCyclicRegion(llvm::Region *region) {
     auto from = edge.first;
     auto to = edge.second;
     // Create edge condition
-    auto z_expr{GetOrCreateReachingCond(from) && GetOrCreateEdgeCond(from, to)};
+    auto z_expr{GetReachingCond(from) && GetOrCreateEdgeCond(from, to)};
     auto cond{ConvertExpr(z_expr.simplify())};
     // Find the statement corresponding to the exiting block
     auto it = std::find(loop_body.begin(), loop_body.end(), block_stmts[from]);
@@ -536,12 +568,6 @@ clang::CompoundStmt *GenerateAST::StructureRegion(llvm::Region *region) {
     return region_stmt;
   }
 
-  // Compute reaching conditions
-  for (auto block : rpo_walk) {
-    if (IsRegionBlock(region, block)) {
-      GetOrCreateReachingCond(block);
-    }
-  }
   // Structure
   region_stmt = is_cyclic ? StructureCyclicRegion(region)
                           : StructureAcyclicRegion(region);
@@ -590,7 +616,12 @@ GenerateAST::Result GenerateAST::run(llvm::Function &func,
   // structurization
   llvm::ReversePostOrderTraversal<llvm::Function *> rpo(&func);
   rpo_walk.assign(rpo.begin(), rpo.end());
-  GetOrCreateReachingCond(rpo_walk[0]);
+  do {
+    reaching_conds_changed = false;
+    for (auto block : rpo_walk) {
+      CreateReachingCond(block);
+    }
+  } while (reaching_conds_changed);
   // Recursively walk regions in post-order and structure
   std::function<void(llvm::Region *)> POWalkSubRegions;
   POWalkSubRegions = [&](llvm::Region *region) {

--- a/lib/AST/Util.cpp
+++ b/lib/AST/Util.cpp
@@ -322,4 +322,17 @@ std::string ClangThingToString(clang::Stmt *stmt) {
   stmt->printPretty(os, nullptr, clang::PrintingPolicy(clang::LangOptions()));
   return s;
 }
+
+z3::goal ApplyTactic(z3::context &ctx, const z3::tactic &tactic,
+                     z3::expr expr) {
+  z3::goal goal(ctx);
+  goal.add(expr.simplify());
+  auto app{tactic(goal)};
+  CHECK(app.size() == 1) << "Unexpected multiple goals in application!";
+  return app[0];
+}
+
+bool Prove(z3::context &ctx, z3::expr expr) {
+  return ApplyTactic(ctx, z3::tactic(ctx, "sat"), !expr).is_decided_unsat();
+}
 }  // namespace rellic

--- a/lib/Decompiler.cpp
+++ b/lib/Decompiler.cpp
@@ -109,12 +109,6 @@ Result<DecompilationResult, DecompilationError> Decompile(
     }
     if (!options.disable_z3) {
       auto zcs{std::make_unique<rellic::Z3CondSimplify>(provenance, *ast_unit)};
-      // Simplifier to use during condition-based refinement
-      z3::tactic tactic{zcs->GetZ3Context(), "skip"};
-      for (auto name : options.condition_based_refinement.z3_tactics) {
-        tactic = tactic & z3::tactic{zcs->GetZ3Context(), name.c_str()};
-      }
-      zcs->SetZ3Tactic(tactic);
       if (options.condition_based_refinement.z3_cond_simplify) {
         cbr_passes.push_back(std::move(zcs));
       }
@@ -167,12 +161,6 @@ Result<DecompilationResult, DecompilationError> Decompile(
     auto& scope_passes{pass_scope.GetPasses()};
     if (!options.disable_z3) {
       auto zcs{std::make_unique<rellic::Z3CondSimplify>(provenance, *ast_unit)};
-      // Simplifier to use during condition-based refinement
-      z3::tactic tactic{zcs->GetZ3Context(), "skip"};
-      for (auto name : options.condition_based_refinement.z3_tactics) {
-        tactic = tactic & z3::tactic{zcs->GetZ3Context(), name.c_str()};
-      }
-      zcs->SetZ3Tactic(tactic);
       if (options.condition_based_refinement.z3_cond_simplify) {
         scope_passes.push_back(std::move(zcs));
       }

--- a/tests/tools/decomp/nested_while.c
+++ b/tests/tools/decomp/nested_while.c
@@ -1,0 +1,16 @@
+int atoi(const char*);
+int printf(const char*, ...);
+
+int main() {
+    int x = atoi("5");
+    if(x > 10) {
+        while(x < 20) {
+            x = x + 1;
+            printf("loop1 x: %d\n", x);
+        }
+    }
+    while(x < 20) {
+        x = x + 1;
+        printf("loop2 x: %d\n", x);
+    }
+}


### PR DESCRIPTION
As suspected, computing reaching conditions via fixpoint is indeed necessary, but was not performed previously due to performance concerns. I've finally been able to find the right Z3 incantation to make conditions simplify enough to compute them sufficiently fast (on my machine at least).