### PR TITLE
Use non opaque ptr type when available

### DIFF
--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -144,7 +144,13 @@ clang::QualType ExprGen::GetQualType(llvm::Type *type) {
     } break;
 
     case llvm::Type::PointerTyID: {
-      result = ast_ctx.VoidPtrTy;
+      auto ptr_type{llvm::cast<llvm::PointerType>(type)};
+      if (ptr_type->isOpaque()) {
+        result = ast_ctx.VoidPtrTy;
+      } else {
+        result = ast_ctx.getPointerType(
+            GetQualType(ptr_type->getNonOpaquePointerElementType()));
+      }
     } break;
 
     case llvm::Type::ArrayTyID: {


### PR DESCRIPTION
I noticed that the LLVM module dumps still featured pointer types even though they should be opaque.
I'm not sure what the deal is with that, but in the meantime I'm using the same trick they are using to print pointer types. As long as this works, it should be better than nothing. It's also trivial to roll back when/if time comes.