### PR TITLE
Fix session cleanup crashes

### DIFF
--- a/lib/Decompiler.cpp
+++ b/lib/Decompiler.cpp
@@ -78,7 +78,8 @@ Result<DecompilationResult, DecompilationError> Decompile(
     rellic::DebugInfoCollector dic;
     dic.visit(*module);
 
-    std::vector<std::string> args{"-Wno-pointer-to-int-cast", "-target",
+    std::vector<std::string> args{"-Wno-pointer-to-int-cast",
+                                  "-Wno-pointer-sign", "-target",
                                   module->getTargetTriple()};
     auto ast_unit{clang::tooling::buildASTFromCodeWithArgs("", args, "out.c")};
 

--- a/tools/headergen/HeaderGen.cpp
+++ b/tools/headergen/HeaderGen.cpp
@@ -93,8 +93,8 @@ int main(int argc, char* argv[]) {
   auto module{rellic::LoadModuleFromFile(llvm_ctx.get(), FLAGS_input)};
   auto dic{std::make_unique<rellic::DebugInfoCollector>()};
   dic->visit(module);
-  std::vector<std::string> args{"-Wno-pointer-to-int-cast", "-target",
-                                module->getTargetTriple()};
+  std::vector<std::string> args{"-Wno-pointer-to-int-cast", "-Wno-pointer-sign",
+                                "-target", module->getTargetTriple()};
   auto ast_unit{clang::tooling::buildASTFromCodeWithArgs("", args, "out.c")};
   rellic::StructGenerator strctgen(*ast_unit);
   rellic::SubprogramGenerator subgen(*ast_unit, strctgen);

--- a/tools/repl/Repl.cpp
+++ b/tools/repl/Repl.cpp
@@ -215,8 +215,8 @@ static void do_load(std::istream& is) {
     return;
   }
 
-  std::vector<std::string> args{"-Wno-pointer-to-int-cast", "-target",
-                                module->getTargetTriple()};
+  std::vector<std::string> args{"-Wno-pointer-to-int-cast", "-Wno-pointer-sign",
+                                "-target", module->getTargetTriple()};
   ast_unit = clang::tooling::buildASTFromCodeWithArgs("", args, "out.c");
   provenance = {};
 

--- a/tools/xref/Xref.cpp
+++ b/tools/xref/Xref.cpp
@@ -250,7 +250,8 @@ static void Decompile(const httplib::Request& req, httplib::Response& res) {
 
   try {
     session.Provenance = {};
-    std::vector<std::string> args{"-Wno-pointer-to-int-cast", "-target",
+    std::vector<std::string> args{"-Wno-pointer-to-int-cast",
+                                  "-Wno-pointer-sign", "-target",
                                   session.Module->getTargetTriple()};
     session.Unit = clang::tooling::buildASTFromCodeWithArgs("", args, "out.c");
     rellic::DebugInfoCollector dic;


### PR DESCRIPTION
Fixes a bug that made `rellic-xref` crash when trying to dispose of old sessions