### PR TITLE
Limit amount of temporary variables

### DIFF
--- a/include/rellic/AST/CondBasedRefine.h
+++ b/include/rellic/AST/CondBasedRefine.h
@@ -42,10 +42,6 @@ class CondBasedRefine : public TransformVisitor<CondBasedRefine> {
 
   z3::expr GetZ3Cond(clang::IfStmt *ifstmt);
 
-  using IfStmtVec = std::vector<clang::IfStmt *>;
-
-  void CreateIfThenElseStmts(IfStmtVec stmts);
-
  protected:
   void RunImpl() override;
 

--- a/include/rellic/AST/ReachBasedRefine.h
+++ b/include/rellic/AST/ReachBasedRefine.h
@@ -43,10 +43,6 @@ class ReachBasedRefine : public TransformVisitor<ReachBasedRefine> {
 
   z3::expr GetZ3Cond(clang::IfStmt *ifstmt);
 
-  using IfStmtVec = std::vector<clang::IfStmt *>;
-
-  void CreateIfElseStmts(IfStmtVec stmts);
-
  protected:
   void RunImpl() override;
 

--- a/include/rellic/BC/Util.h
+++ b/include/rellic/BC/Util.h
@@ -67,4 +67,6 @@ void RemoveInsertValues(llvm::Module &module);
 // Converts by value array arguments and wraps them into a struct, so that
 // semantics are preserved in C
 void ConvertArrayArguments(llvm::Module &module);
+
+void FindRedundantLoads(llvm::Module &module);
 }  // namespace rellic

--- a/lib/AST/CondBasedRefine.cpp
+++ b/lib/AST/CondBasedRefine.cpp
@@ -11,23 +11,11 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include <cstddef>
+
+#include "rellic/AST/Util.h"
+
 namespace rellic {
-
-namespace {
-
-using IfStmtVec = std::vector<clang::IfStmt *>;
-
-static IfStmtVec GetIfStmts(clang::CompoundStmt *compound) {
-  IfStmtVec result;
-  for (auto stmt : compound->body()) {
-    if (auto ifstmt = clang::dyn_cast<clang::IfStmt>(stmt)) {
-      result.push_back(ifstmt);
-    }
-  }
-  return result;
-}
-
-}  // namespace
 
 CondBasedRefine::CondBasedRefine(Provenance &provenance, clang::ASTUnit &unit)
     : TransformVisitor<CondBasedRefine>(provenance, unit),
@@ -41,85 +29,65 @@ z3::expr CondBasedRefine::GetZ3Cond(clang::IfStmt *ifstmt) {
   return expr.simplify();
 }
 
-void CondBasedRefine::CreateIfThenElseStmts(IfStmtVec worklist) {
-  auto RemoveFromWorkList = [&worklist](clang::Stmt *stmt) {
-    auto it = std::find(worklist.begin(), worklist.end(), stmt);
-    if (it != worklist.end()) {
-      worklist.erase(it);
-    }
-  };
+bool CondBasedRefine::VisitCompoundStmt(clang::CompoundStmt *compound) {
+  std::vector<clang::Stmt *> body{compound->body_begin(), compound->body_end()};
+  bool did_something{false};
+  for (size_t i{0}; i + 1 < body.size() && !Stopped(); ++i) {
+    auto if_a{clang::dyn_cast<clang::IfStmt>(body[i])};
+    auto if_b{clang::dyn_cast<clang::IfStmt>(body[i + 1])};
 
-  auto ThenTest = [this](z3::expr lhs, z3::expr rhs) {
-    return Prove(*z3_ctx, lhs == rhs);
-  };
-
-  auto ElseTest = [this](z3::expr lhs, z3::expr rhs) {
-    return Prove(*z3_ctx, lhs == !rhs);
-  };
-
-  auto CombineTest = [this](z3::expr lhs, z3::expr rhs) {
-    return Prove(*z3_ctx, z3::implies(rhs, lhs));
-  };
-
-  while (!worklist.empty()) {
-    auto lhs = *worklist.begin();
-    RemoveFromWorkList(lhs);
-    // Prepare conditions according to which we're going to
-    // cluster statements according to the whole `lhs`
-    // condition.
-    auto lcond = GetZ3Cond(lhs);
-    // Get branch candidates wrt `clause`
-    std::vector<clang::Stmt *> thens({lhs}), elses;
-    for (auto rhs : worklist) {
-      auto rcond = GetZ3Cond(rhs);
-      if (ThenTest(lcond, rcond) || CombineTest(lcond, rcond)) {
-        thens.push_back(rhs);
-      } else if (ElseTest(lcond, rcond) || CombineTest(!lcond, rcond)) {
-        elses.push_back(rhs);
-      }
-    }
-
-    // Check if we have enough statements to work with
-    if (thens.size() + elses.size() < 2) {
+    if (!if_a || !if_b) {
       continue;
     }
 
-    // Erase then statements from the AST and `worklist`
-    for (auto stmt : thens) {
-      RemoveFromWorkList(stmt);
-      substitutions[stmt] = nullptr;
-    }
-    // Create our new if-then
-    auto sub = ast.CreateIf(lhs->getCond(), ast.CreateCompoundStmt(thens));
-    // Create an else branch if possible
-    if (!elses.empty()) {
-      // Erase else statements from the AST and `worklist`
-      for (auto stmt : elses) {
-        RemoveFromWorkList(stmt);
-        substitutions[stmt] = nullptr;
-      }
-      // Add the else branch
-      sub->setElse(ast.CreateCompoundStmt(elses));
-    }
-    // Replace `lhs` with the new `sub`
-    substitutions[lhs] = sub;
-  }
-}
+    auto then_a{if_a->getThen()};
+    auto then_b{if_b->getThen()};
 
-bool CondBasedRefine::VisitCompoundStmt(clang::CompoundStmt *compound) {
-  // DLOG(INFO) << "VisitCompoundStmt";
-  // Create if-then-else substitutions for IfStmts in `compound`
-  CreateIfThenElseStmts(GetIfStmts(compound));
-  // Apply created if-then-else substitutions and
-  // create a replacement for `compound`
-  if (ReplaceChildren(compound, substitutions)) {
-    std::vector<clang::Stmt *> new_body;
-    for (auto stmt : compound->body()) {
-      if (stmt) {
-        new_body.push_back(stmt);
+    auto else_a{if_a->getElse()};
+    auto else_b{if_b->getElse()};
+
+    auto cond_a{GetZ3Cond(if_a)};
+    auto cond_b{GetZ3Cond(if_b)};
+    if (Prove(*z3_ctx, cond_a == cond_b)) {
+      std::vector<clang::Stmt *> new_then_body{then_a, then_b};
+      auto new_then{ast.CreateCompoundStmt(new_then_body)};
+      auto new_if{ast.CreateIf(if_a->getCond(), new_then)};
+
+      if (else_a || else_b) {
+        std::vector<clang::Stmt *> new_else_body;
+        if (else_a) {
+          new_else_body.push_back(else_a);
+        }
+        if (else_b) {
+          new_else_body.push_back(else_b);
+        }
+        new_if->setElse(ast.CreateCompoundStmt(new_else_body));
       }
+      body[i] = new_if;
+      body.erase(std::next(body.begin(), i + 1));
+      did_something = true;
+    } else if (Prove(*z3_ctx, cond_a == !cond_b)) {
+      std::vector<clang::Stmt *> new_then_body{then_a};
+      if (else_b) {
+        new_then_body.push_back(else_b);
+      }
+      auto new_then{ast.CreateCompoundStmt(new_then_body)};
+      auto new_if{ast.CreateIf(if_a->getCond(), new_then)};
+
+      std::vector<clang::Stmt *> new_else_body;
+      if (else_a) {
+        new_else_body.push_back(else_a);
+      }
+      new_else_body.push_back(then_b);
+      new_if->setElse(ast.CreateCompoundStmt(new_else_body));
+      body[i] = new_if;
+      body.erase(std::next(body.begin(), i + 1));
+      did_something = true;
     }
-    substitutions[compound] = ast.CreateCompoundStmt(new_body);
+  }
+
+  if (did_something) {
+    substitutions[compound] = ast.CreateCompoundStmt(body);
   }
   return !Stopped();
 }

--- a/lib/AST/CondBasedRefine.cpp
+++ b/lib/AST/CondBasedRefine.cpp
@@ -50,8 +50,9 @@ bool CondBasedRefine::VisitCompoundStmt(clang::CompoundStmt *compound) {
     auto cond_b{GetZ3Cond(if_b)};
 
     clang::IfStmt *new_if{};
+    std::vector<clang::Stmt *> new_then_body{then_a};
     if (Prove(*z3_ctx, cond_a == cond_b)) {
-      std::vector<clang::Stmt *> new_then_body{then_a, then_b};
+      new_then_body.push_back(then_b);
       auto new_then{ast.CreateCompoundStmt(new_then_body)};
       new_if = ast.CreateIf(if_a->getCond(), new_then);
 
@@ -66,7 +67,6 @@ bool CondBasedRefine::VisitCompoundStmt(clang::CompoundStmt *compound) {
         new_if->setElse(ast.CreateCompoundStmt(new_else_body));
       }
     } else if (Prove(*z3_ctx, cond_a == !cond_b)) {
-      std::vector<clang::Stmt *> new_then_body{then_a};
       if (else_b) {
         new_then_body.push_back(else_b);
       }

--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -1245,8 +1245,10 @@ void IRToASTVisitor::VisitFunctionDecl(llvm::Function &func) {
       fdecl->addDecl(var);
     } else if (inst.hasNUsesOrMore(2) ||
                (inst.hasNUsesOrMore(1) && llvm::isa<llvm::CallInst>(inst)) ||
-               llvm::isa<llvm::LoadInst>(inst) ||
                llvm::isa<llvm::PHINode>(inst)) {
+      if (inst.getMetadata("rellic.notemp")) {
+        continue;
+      }
       if (!inst.getType()->isVoidTy()) {
         auto GetPrefix{[&](llvm::Instruction *inst) {
           if (llvm::isa<llvm::CallInst>(inst)) {

--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -1245,6 +1245,7 @@ void IRToASTVisitor::VisitFunctionDecl(llvm::Function &func) {
       fdecl->addDecl(var);
     } else if (inst.hasNUsesOrMore(2) ||
                (inst.hasNUsesOrMore(1) && llvm::isa<llvm::CallInst>(inst)) ||
+               llvm::isa<llvm::LoadInst>(inst) ||
                llvm::isa<llvm::PHINode>(inst)) {
       if (inst.getMetadata("rellic.notemp")) {
         continue;

--- a/lib/AST/ReachBasedRefine.cpp
+++ b/lib/AST/ReachBasedRefine.cpp
@@ -11,6 +11,8 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include "rellic/AST/Util.h"
+
 namespace rellic {
 
 ReachBasedRefine::ReachBasedRefine(Provenance &provenance, clang::ASTUnit &unit)
@@ -30,37 +32,103 @@ bool ReachBasedRefine::VisitCompoundStmt(clang::CompoundStmt *compound) {
   z3::expr_vector conds{*z3_ctx};
   bool done_something{false};
   for (size_t i{0}; i < body.size(); ++i) {
-    if (auto if_stmt = clang::dyn_cast<clang::IfStmt>(body[i])) {
-      ifs.push_back(if_stmt);
-      auto cond{GetZ3Cond(if_stmt)};
-      if (!if_stmt->getElse() && Prove(*z3_ctx, !(cond && z3::mk_or(conds)))) {
-        conds.push_back(GetZ3Cond(if_stmt));
+    auto if_stmt{clang::dyn_cast<clang::IfStmt>(body[i])};
+    if (!if_stmt) {
+      ifs.clear();
+      conds.resize(0);
+      continue;
+    }
 
-        if (Prove(*z3_ctx, z3::mk_or(conds)) && ifs.size() > 2) {
-          auto last_if{ifs[0]};
-          for (auto stmt : ifs) {
-            if (stmt == ifs.front()) {
-              continue;
-            }
-            if (stmt == ifs.back()) {
-              last_if->setElse(stmt->getThen());
-            } else {
-              last_if->setElse(stmt);
-              last_if = stmt;
-            }
-          }
+    ifs.push_back(if_stmt);
+    auto cond{GetZ3Cond(if_stmt)};
 
-          size_t start_delete{i - (ifs.size() - 2)};
-          size_t end_delete{i};
-          body.erase(body.erase(std::next(body.begin(), start_delete),
-                                std::next(body.begin(), end_delete)));
-          done_something = true;
-          break;
-        }
+    if (if_stmt->getElse()) {
+      // We cannot link `if` statements that contain `else` branches
+      ifs.clear();
+      conds.resize(0);
+      continue;
+    }
+
+    // Is the current `if` statement unreachable from all the others?
+    bool is_unreachable{Prove(*z3_ctx, !(cond && z3::mk_or(conds)))};
+
+    if (!is_unreachable) {
+      ifs.clear();
+      conds.resize(0);
+      continue;
+    }
+
+    conds.push_back(GetZ3Cond(if_stmt));
+
+    // Do the collected statements cover all possibilities?
+    auto is_complete{Prove(*z3_ctx, z3::mk_or(conds))};
+
+    if (ifs.size() <= 2 || !is_complete) {
+      // We need to collect more statements
+      continue;
+    }
+
+    /*
+    `body` will look like this at this point:
+
+      ...
+      i - n    : ...
+      i - n + 1: if(cond_1) { }
+      i - n + 2: if(cond_2) { }
+      ...
+      i - 1    : if(cond_n-1) { }
+      i        : if(cond_n) { }
+      ...
+
+    and we want to chain all of the statements together:
+      ...
+      i - n    : ...
+      i - n + 1: if(cond_1) { } else if(cond_2) { } ... else if(cond_n) { }
+      i - n + 2: if(cond_2) { } else if(cond_3) { } ... else if(cond_n) { }
+      ...
+      i - 1    : if(cond_n-1) { } else if(cond_n) { }
+      i        : if(cond_n) { }
+      ...
+    */
+    auto last_if{ifs[0]};
+    for (auto stmt : ifs) {
+      if (stmt == ifs.front()) {
+        continue;
+      }
+      if (stmt == ifs.back()) {
+        last_if->setElse(stmt->getThen());
+      } else {
+        last_if->setElse(stmt);
+        last_if = stmt;
       }
     }
-    ifs.clear();
-    conds.resize(0);
+
+    /*
+    `body` will look like this at this point:
+
+      ...
+      i - n    : ...
+      i - n + 1: if(cond_1) { } else if(cond_2) { } ... else if(cond_n) { }
+      i - n + 2: if(cond_2) { } else if(cond_3) { } ... else if(cond_n) { }
+      ...
+      i - 1    : if(cond_n-1) { } else if(cond_n) { }
+      i        : if(cond_n) { }
+      ...
+
+    but since we chained all of the statements into the first, we want to remove
+    the others from the body:
+
+      ...
+      i - n    : ...
+      i - n + 1: if(cond_1) { } else if(cond_2) { } else if ...
+      ...
+    */
+    size_t start_delete{i - (ifs.size() - 2)};
+    size_t end_delete{i};
+    body.erase(body.erase(std::next(body.begin(), start_delete),
+                          std::next(body.begin(), end_delete)));
+    done_something = true;
+    break;
   }
 
   if (done_something) {

--- a/lib/AST/ReachBasedRefine.cpp
+++ b/lib/AST/ReachBasedRefine.cpp
@@ -30,6 +30,7 @@ bool ReachBasedRefine::VisitCompoundStmt(clang::CompoundStmt *compound) {
   std::vector<clang::Stmt *> body{compound->body_begin(), compound->body_end()};
   std::vector<clang::IfStmt *> ifs;
   z3::expr_vector conds{*z3_ctx};
+
   bool done_something{false};
   for (size_t i{0}; i < body.size(); ++i) {
     auto if_stmt{clang::dyn_cast<clang::IfStmt>(body[i])};

--- a/lib/AST/Util.cpp
+++ b/lib/AST/Util.cpp
@@ -346,6 +346,13 @@ z3::goal ApplyTactic(z3::context &ctx, const z3::tactic &tactic,
 }
 
 bool Prove(z3::context &ctx, z3::expr expr) {
-  return ApplyTactic(ctx, z3::tactic(ctx, "sat"), !expr).is_decided_unsat();
+  z3::tactic aig(ctx, "aig");
+  z3::tactic simplify(ctx, "simplify");
+  z3::tactic ctx_solver_simplify(ctx, "ctx-solver-simplify");
+  auto simpl{simplify & aig & ctx_solver_simplify};
+
+  return ApplyTactic(ctx, z3::tactic(ctx, "sat"),
+                     ApplyTactic(ctx, simpl, !expr).as_expr())
+      .is_decided_unsat();
 }
 }  // namespace rellic

--- a/lib/AST/Util.cpp
+++ b/lib/AST/Util.cpp
@@ -346,13 +346,7 @@ z3::goal ApplyTactic(z3::context &ctx, const z3::tactic &tactic,
 }
 
 bool Prove(z3::context &ctx, z3::expr expr) {
-  z3::tactic aig(ctx, "aig");
-  z3::tactic simplify(ctx, "simplify");
-  z3::tactic ctx_solver_simplify(ctx, "ctx-solver-simplify");
-  auto simpl{simplify & aig & ctx_solver_simplify};
-
-  return ApplyTactic(ctx, z3::tactic(ctx, "sat"),
-                     ApplyTactic(ctx, simpl, !expr).as_expr())
+  return ApplyTactic(ctx, z3::tactic(ctx, "sat"), !(expr.simplify()))
       .is_decided_unsat();
 }
 }  // namespace rellic

--- a/lib/BC/Util.cpp
+++ b/lib/BC/Util.cpp
@@ -437,4 +437,61 @@ void ConvertArrayArguments(llvm::Module &m) {
   CHECK(VerifyModule(&m)) << "Transformation broke module correctness";
 }
 
+static void FindRedundantLoads(llvm::Function &func) {
+  auto HasStoreBeforeUse = [&](llvm::Value *ptr, llvm::User *user,
+                               llvm::LoadInst *load) {
+    std::unordered_set<llvm::BasicBlock *> visited_blocks;
+    std::vector<llvm::Instruction *> work_list;
+    auto inst{llvm::cast<llvm::Instruction>(user)};
+    work_list.push_back(inst);
+    while (!work_list.empty()) {
+      inst = work_list.back();
+      work_list.pop_back();
+      auto bb{inst->getParent()};
+      visited_blocks.insert(bb);
+
+      while (inst) {
+        if (auto store = llvm::dyn_cast<llvm::StoreInst>(inst)) {
+          if (store->getPointerOperand() == ptr) {
+            return true;
+          }
+        }
+        if (inst == load) {
+          return false;
+        }
+        inst = inst->getPrevNode();
+      }
+      for (auto pred : llvm::predecessors(bb)) {
+        if (!visited_blocks.count(pred)) {
+          work_list.push_back(pred->getTerminator());
+        }
+      }
+    }
+
+    return false;
+  };
+
+  for (auto &inst : llvm::instructions(func)) {
+    if (auto load = llvm::dyn_cast<llvm::LoadInst>(&inst)) {
+      for (auto &use : load->uses()) {
+        auto ptr{load->getPointerOperand()};
+        if (llvm::isa<llvm::GlobalValue>(ptr)) {
+          continue;
+        }
+        if (HasStoreBeforeUse(ptr, use.getUser(), load)) {
+          continue;
+        }
+        load->setMetadata("rellic.notemp",
+                          llvm::MDNode::get(func.getContext(), {}));
+      }
+    }
+  }
+}
+
+void FindRedundantLoads(llvm::Module &module) {
+  for (auto &func : module.functions()) {
+    FindRedundantLoads(func);
+  }
+}
+
 }  // namespace rellic

--- a/lib/BC/Util.cpp
+++ b/lib/BC/Util.cpp
@@ -475,7 +475,7 @@ static void FindRedundantLoads(llvm::Function &func) {
     if (auto load = llvm::dyn_cast<llvm::LoadInst>(&inst)) {
       for (auto &use : load->uses()) {
         auto ptr{load->getPointerOperand()};
-        if (llvm::isa<llvm::GlobalValue>(ptr)) {
+        if (!llvm::isa<llvm::AllocaInst>(ptr)) {
           continue;
         }
         if (HasStoreBeforeUse(ptr, use.getUser(), load)) {

--- a/lib/Decompiler.cpp
+++ b/lib/Decompiler.cpp
@@ -73,6 +73,7 @@ Result<DecompilationResult, DecompilationError> Decompile(
 
     ConvertArrayArguments(*module);
     RemoveInsertValues(*module);
+    FindRedundantLoads(*module);
 
     InitOptPasses();
     rellic::DebugInfoCollector dic;

--- a/tools/xref/Xref.cpp
+++ b/tools/xref/Xref.cpp
@@ -247,6 +247,7 @@ static void LoadModule(const httplib::Request& req, httplib::Response& res) {
     return;
   }
   session.Module = std::unique_ptr<llvm::Module>(mod);
+  rellic::FindRedundantLoads(*session.Module);
   llvm::json::Object msg{{"message", "Ok."}};
   SendJSON(res, msg);
   res.status = 200;


### PR DESCRIPTION
Rellic generates temporary variables for every load in order to maintain an SSA-like structure. This also produces a lot of temporary variables which are annoying to read.

The observation is that a temporary is needed for a `load` of an `alloca` only if a `store` occurred between the use of said `load` and the `load` itself.

E.g.

```llvm
%alloca = alloca ...
store sth, %alloca
%load = load %alloca
%foo = add %load, ... ; %load doesn't need a temporary variable
```

```llvm
%alloca = alloca ...
store sth, %alloca
%load = load %alloca
store sthelse, %alloca
%foo = add %load, ... ; %load needs a temporary variable
```