### PR TITLE
Default to signed output to look better by default

### DIFF
--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -215,7 +215,7 @@ clang::QualType ExprGen::GetQualType(llvm::Type *type) {
     case llvm::Type::IntegerTyID: {
       auto size{type->getIntegerBitWidth()};
       CHECK(size > 0) << "Integer bit width has to be greater than 0";
-      result = ast.GetLeastIntTypeForBitWidth(size, /*sign=*/0);
+      result = ast.GetLeastIntTypeForBitWidth(size, /*sign=*/1);
     } break;
 
     case llvm::Type::FunctionTyID: {


### PR DESCRIPTION
Should be a better default since most things tend to be signed to begin with
```
unsigned char var_2004__CBx13_D[13] = "Hello world!\000";

unsigned int main(unsigned int arg0, void *arg1, void *arg2) {
    puts(&var_2004__CBx13_D);
    return 0U;
}
```

```
signed char var_2004__CBx13_D[13] = "Hello world!\000";

int main(int arg0, void *arg1, void *arg2) {
    puts(&var_2004__CBx13_D);
    return 0U;
}
```