### PR TITLE
Type providers

### DIFF
--- a/include/rellic/AST/DecompilationContext.h
+++ b/include/rellic/AST/DecompilationContext.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021-present, Trail of Bits, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed in accordance with the terms specified in
+ * the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <clang/AST/ASTContext.h>
+#include <clang/Frontend/ASTUnit.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Value.h>
+#include <z3++.h>
+
+#include <unordered_map>
+
+#include "rellic/AST/ASTBuilder.h"
+#include "rellic/AST/TypeProvider.h"
+
+namespace rellic {
+
+struct DecompilationContext {
+  using StmtToIRMap = std::unordered_map<clang::Stmt *, llvm::Value *>;
+  using ExprToUseMap = std::unordered_map<clang::Expr *, llvm::Use *>;
+  using IRToTypeDeclMap = std::unordered_map<llvm::Type *, clang::TypeDecl *>;
+  using IRToValDeclMap = std::unordered_map<llvm::Value *, clang::ValueDecl *>;
+  using IRToStmtMap = std::unordered_map<llvm::Value *, clang::Stmt *>;
+  using ArgToTempMap = std::unordered_map<llvm::Argument *, clang::VarDecl *>;
+  using BlockToUsesMap =
+      std::unordered_map<llvm::BasicBlock *, std::vector<llvm::Use *>>;
+  using Z3CondMap = std::unordered_map<clang::Stmt *, unsigned>;
+
+  using BBEdge = std::pair<llvm::BasicBlock *, llvm::BasicBlock *>;
+  using BrEdge = std::pair<llvm::BranchInst *, bool>;
+  using SwEdge = std::pair<llvm::SwitchInst *, llvm::ConstantInt *>;
+
+  DecompilationContext(clang::ASTUnit &ast_unit);
+
+  clang::ASTUnit &ast_unit;
+  clang::ASTContext &ast_ctx;
+  ASTBuilder ast;
+
+  std::unique_ptr<TypeProviderCombiner> type_provider;
+
+  StmtToIRMap stmt_provenance;
+  ExprToUseMap use_provenance;
+  IRToTypeDeclMap type_decls;
+  IRToValDeclMap value_decls;
+  ArgToTempMap temp_decls;
+  BlockToUsesMap outgoing_uses;
+  z3::context z3_ctx;
+  z3::expr_vector z3_exprs{z3_ctx};
+  Z3CondMap conds;
+
+  clang::Expr *marker_expr;
+
+  std::unordered_map<unsigned, BrEdge> z3_br_edges_inv;
+
+  // Pairs do not have a std::hash specialization so we can't use unordered maps
+  // here. If this turns out to be a performance issue, investigate adding hash
+  // specializations for these specifically
+  std::map<BrEdge, unsigned> z3_br_edges;
+
+  std::unordered_map<llvm::SwitchInst *, unsigned> z3_sw_vars;
+  std::unordered_map<unsigned, llvm::SwitchInst *> z3_sw_vars_inv;
+  std::map<SwEdge, unsigned> z3_sw_edges;
+
+  std::map<BBEdge, unsigned> z3_edges;
+  std::unordered_map<llvm::BasicBlock *, unsigned> reaching_conds;
+
+  size_t num_literal_structs = 0;
+  size_t num_declared_structs = 0;
+
+  // Inserts an expression into z3_exprs and returns its index
+  unsigned InsertZExpr(const z3::expr &e);
+
+  clang::QualType GetQualType(llvm::Type *type);
+};
+
+}  // namespace rellic

--- a/include/rellic/AST/TypeProvider.h
+++ b/include/rellic/AST/TypeProvider.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-present, Trail of Bits, Inc.
+ * Copyright (c) 2022-present, Trail of Bits, Inc.
  * All rights reserved.
  *
  * This source code is licensed in accordance with the terms specified in

--- a/include/rellic/AST/TypeProvider.h
+++ b/include/rellic/AST/TypeProvider.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021-present, Trail of Bits, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed in accordance with the terms specified in
+ * the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/GlobalVariable.h>
+
+#include "rellic/AST/ASTBuilder.h"
+
+namespace rellic {
+struct DecompilationContext;
+
+class TypeProvider {
+ protected:
+  DecompilationContext& dec_ctx;
+
+ public:
+  TypeProvider(DecompilationContext& dec_ctx);
+  virtual ~TypeProvider();
+
+  // Returns the return type of a function if available
+  virtual clang::QualType GetFunctionReturnType(llvm::Function& func);
+
+  // Returns the type of the argument if available
+  virtual clang::QualType GetArgumentType(llvm::Argument& arg);
+
+  // Returns the type of a global variable if available
+  virtual clang::QualType GetGlobalVarType(llvm::GlobalVariable& gvar);
+};
+
+class TypeProviderCombiner : public TypeProvider {
+ private:
+  std::vector<std::unique_ptr<TypeProvider>> providers;
+
+ public:
+  TypeProviderCombiner(DecompilationContext& dec_ctx);
+  template <typename T>
+  void AddProvider() {
+    providers.push_back(std::make_unique<T>(dec_ctx));
+  }
+
+  void AddProvider(std::unique_ptr<TypeProvider> provider);
+
+  clang::QualType GetFunctionReturnType(llvm::Function& func) override;
+  clang::QualType GetArgumentType(llvm::Argument& arg) override;
+  clang::QualType GetGlobalVarType(llvm::GlobalVariable& gvar) override;
+};
+}  // namespace rellic

--- a/include/rellic/AST/TypeProvider.h
+++ b/include/rellic/AST/TypeProvider.h
@@ -24,13 +24,16 @@ class TypeProvider {
   TypeProvider(DecompilationContext& dec_ctx);
   virtual ~TypeProvider();
 
-  // Returns the return type of a function if available
+  // Returns the return type of a function if available.
+  // A null return value is assumed to mean that no info is available.
   virtual clang::QualType GetFunctionReturnType(llvm::Function& func);
 
-  // Returns the type of the argument if available
+  // Returns the type of the argument if available.
+  // A null return value is assumed to mean that no info is available.
   virtual clang::QualType GetArgumentType(llvm::Argument& arg);
 
-  // Returns the type of a global variable if available
+  // Returns the type of a global variable if available.
+  // A null return value is assumed to mean that no info is available.
   virtual clang::QualType GetGlobalVarType(llvm::GlobalVariable& gvar);
 };
 
@@ -40,9 +43,10 @@ class TypeProviderCombiner : public TypeProvider {
 
  public:
   TypeProviderCombiner(DecompilationContext& dec_ctx);
-  template <typename T>
-  void AddProvider() {
-    providers.push_back(std::make_unique<T>(dec_ctx));
+  template <typename T, typename... TArgs>
+  void AddProvider(TArgs&&... args) {
+    providers.push_back(
+        std::make_unique<T>(dec_ctx, std::forward<TArgs>(args)...));
   }
 
   void AddProvider(std::unique_ptr<TypeProvider> provider);

--- a/include/rellic/AST/Util.h
+++ b/include/rellic/AST/Util.h
@@ -104,6 +104,8 @@ struct DecompilationContext {
 
   // Inserts an expression into z3_exprs and returns its index
   unsigned InsertZExpr(const z3::expr &e);
+
+  clang::QualType GetQualType(llvm::Type *type);
 };
 
 template <typename TKey1, typename TKey2, typename TKey3, typename TValue>

--- a/include/rellic/AST/Util.h
+++ b/include/rellic/AST/Util.h
@@ -19,6 +19,7 @@
 #include <unordered_map>
 
 #include "rellic/AST/ASTBuilder.h"
+#include "rellic/AST/TypeProvider.h"
 
 namespace rellic {
 
@@ -72,6 +73,8 @@ struct DecompilationContext {
   clang::ASTUnit &ast_unit;
   clang::ASTContext &ast_ctx;
   ASTBuilder ast;
+
+  std::unique_ptr<TypeProviderCombiner> type_provider;
 
   StmtToIRMap stmt_provenance;
   ExprToUseMap use_provenance;

--- a/include/rellic/AST/Util.h
+++ b/include/rellic/AST/Util.h
@@ -8,18 +8,7 @@
 
 #pragma once
 
-#include <clang/AST/ASTContext.h>
-#include <clang/AST/DeclBase.h>
-#include <clang/AST/Stmt.h>
-#include <clang/Frontend/ASTUnit.h>
-#include <llvm/IR/Instructions.h>
-#include <llvm/IR/Value.h>
-#include <z3++.h>
-
-#include <unordered_map>
-
-#include "rellic/AST/ASTBuilder.h"
-#include "rellic/AST/TypeProvider.h"
+#include "rellic/AST/DecompilationContext.h"
 
 namespace rellic {
 
@@ -52,64 +41,6 @@ size_t GetNumDecls(clang::DeclContext *decl_ctx) {
   }
   return result;
 }
-
-struct DecompilationContext {
-  using StmtToIRMap = std::unordered_map<clang::Stmt *, llvm::Value *>;
-  using ExprToUseMap = std::unordered_map<clang::Expr *, llvm::Use *>;
-  using IRToTypeDeclMap = std::unordered_map<llvm::Type *, clang::TypeDecl *>;
-  using IRToValDeclMap = std::unordered_map<llvm::Value *, clang::ValueDecl *>;
-  using IRToStmtMap = std::unordered_map<llvm::Value *, clang::Stmt *>;
-  using ArgToTempMap = std::unordered_map<llvm::Argument *, clang::VarDecl *>;
-  using BlockToUsesMap =
-      std::unordered_map<llvm::BasicBlock *, std::vector<llvm::Use *>>;
-  using Z3CondMap = std::unordered_map<clang::Stmt *, unsigned>;
-
-  using BBEdge = std::pair<llvm::BasicBlock *, llvm::BasicBlock *>;
-  using BrEdge = std::pair<llvm::BranchInst *, bool>;
-  using SwEdge = std::pair<llvm::SwitchInst *, llvm::ConstantInt *>;
-
-  DecompilationContext(clang::ASTUnit &ast_unit);
-
-  clang::ASTUnit &ast_unit;
-  clang::ASTContext &ast_ctx;
-  ASTBuilder ast;
-
-  std::unique_ptr<TypeProviderCombiner> type_provider;
-
-  StmtToIRMap stmt_provenance;
-  ExprToUseMap use_provenance;
-  IRToTypeDeclMap type_decls;
-  IRToValDeclMap value_decls;
-  ArgToTempMap temp_decls;
-  BlockToUsesMap outgoing_uses;
-  z3::context z3_ctx;
-  z3::expr_vector z3_exprs{z3_ctx};
-  Z3CondMap conds;
-
-  clang::Expr *marker_expr;
-
-  std::unordered_map<unsigned, BrEdge> z3_br_edges_inv;
-
-  // Pairs do not have a std::hash specialization so we can't use unordered maps
-  // here. If this turns out to be a performance issue, investigate adding hash
-  // specializations for these specifically
-  std::map<BrEdge, unsigned> z3_br_edges;
-
-  std::unordered_map<llvm::SwitchInst *, unsigned> z3_sw_vars;
-  std::unordered_map<unsigned, llvm::SwitchInst *> z3_sw_vars_inv;
-  std::map<SwEdge, unsigned> z3_sw_edges;
-
-  std::map<BBEdge, unsigned> z3_edges;
-  std::unordered_map<llvm::BasicBlock *, unsigned> reaching_conds;
-
-  size_t num_literal_structs = 0;
-  size_t num_declared_structs = 0;
-
-  // Inserts an expression into z3_exprs and returns its index
-  unsigned InsertZExpr(const z3::expr &e);
-
-  clang::QualType GetQualType(llvm::Type *type);
-};
 
 template <typename TKey1, typename TKey2, typename TKey3, typename TValue>
 void CopyProvenance(TKey1 *from, TKey2 *to,

--- a/lib/AST/GenerateAST.cpp
+++ b/lib/AST/GenerateAST.cpp
@@ -336,11 +336,11 @@ StmtVec GenerateAST::CreateRegionStmts(llvm::Region *region) {
     } else {
       // Create a compound, wrapping the block
       auto block_body = CreateBasicBlockStmts(block);
-      compound = ast.CreateCompoundStmt(block_body);
+      compound = dec_ctx.ast.CreateCompoundStmt(block_body);
     }
     // Gate the compound behind a reaching condition
     auto z_expr{GetReachingCond(block)};
-    block_stmts[block] = ast.CreateIf(dec_ctx.marker_expr, compound);
+    block_stmts[block] = dec_ctx.ast.CreateIf(dec_ctx.marker_expr, compound);
     dec_ctx.conds[block_stmts[block]] =
         dec_ctx.InsertZExpr(dec_ctx.z3_exprs[z_expr]);
     // Store the compound
@@ -400,7 +400,7 @@ void GenerateAST::RefineLoopSuccessors(llvm::Loop *loop, BBSet &members,
 clang::CompoundStmt *GenerateAST::StructureAcyclicRegion(llvm::Region *region) {
   DLOG(INFO) << "Region " << GetRegionNameStr(region) << " is acyclic";
   auto region_body = CreateRegionStmts(region);
-  return ast.CreateCompoundStmt(region_body);
+  return dec_ctx.ast.CreateCompoundStmt(region_body);
 }
 
 clang::CompoundStmt *GenerateAST::StructureCyclicRegion(llvm::Region *region) {
@@ -413,7 +413,7 @@ clang::CompoundStmt *GenerateAST::StructureCyclicRegion(llvm::Region *region) {
   // a recognized natural loop. Cyclic regions may only be fragments
   // of a larger loop structure.
   if (!loop) {
-    return ast.CreateCompoundStmt(region_body);
+    return dec_ctx.ast.CreateCompoundStmt(region_body);
   }
   // Refine loop members and successors without invalidating LoopInfo
   BBSet members, successors;
@@ -447,9 +447,9 @@ clang::CompoundStmt *GenerateAST::StructureCyclicRegion(llvm::Region *region) {
     auto it = std::find(loop_body.begin(), loop_body.end(), block_stmts[from]);
     CHECK(it != loop_body.end());
     // Create a loop exiting `break` statement
-    StmtVec break_stmt({ast.CreateBreak()});
-    auto exit_stmt =
-        ast.CreateIf(dec_ctx.marker_expr, ast.CreateCompoundStmt(break_stmt));
+    StmtVec break_stmt({dec_ctx.ast.CreateBreak()});
+    auto exit_stmt = dec_ctx.ast.CreateIf(
+        dec_ctx.marker_expr, dec_ctx.ast.CreateCompoundStmt(break_stmt));
     // Create edge condition
     dec_ctx.conds[exit_stmt] = dec_ctx.InsertZExpr(
         (ToExpr(GetReachingCond(from)) && ToExpr(GetOrCreateEdgeCond(from, to)))
@@ -458,12 +458,12 @@ clang::CompoundStmt *GenerateAST::StructureCyclicRegion(llvm::Region *region) {
     loop_body.insert(std::next(it), exit_stmt);
   }
   // Create the loop statement
-  auto loop_stmt =
-      ast.CreateWhile(ast.CreateTrue(), ast.CreateCompoundStmt(loop_body));
+  auto loop_stmt = dec_ctx.ast.CreateWhile(
+      dec_ctx.ast.CreateTrue(), dec_ctx.ast.CreateCompoundStmt(loop_body));
   // Insert it at the beginning of the region body
   region_body.insert(region_body.begin(), loop_stmt);
   // Structure the rest of the loop body as a acyclic region
-  return ast.CreateCompoundStmt(region_body);
+  return dec_ctx.ast.CreateCompoundStmt(region_body);
 }
 
 clang::CompoundStmt *GenerateAST::StructureSwitchRegion(llvm::Region *region) {
@@ -475,15 +475,15 @@ clang::CompoundStmt *GenerateAST::StructureSwitchRegion(llvm::Region *region) {
   auto sw_inst{
       llvm::cast<llvm::SwitchInst>(region->getEntry()->getTerminator())};
   auto cond{ast_gen.CreateOperandExpr(sw_inst->getOperandUse(0))};
-  auto sw_stmt{ast.CreateSwitchStmt(cond)};
+  auto sw_stmt{dec_ctx.ast.CreateSwitchStmt(cond)};
   StmtVec sw_body;
 
   auto default_dest{sw_inst->getDefaultDest()};
   if (default_dest != region->getExit()) {
     auto default_body{CreateBasicBlockStmts(default_dest)};
-    sw_body.push_back(
-        ast.CreateDefaultStmt(ast.CreateCompoundStmt(default_body)));
-    sw_body.push_back(ast.CreateBreak());
+    sw_body.push_back(dec_ctx.ast.CreateDefaultStmt(
+        dec_ctx.ast.CreateCompoundStmt(default_body)));
+    sw_body.push_back(dec_ctx.ast.CreateBreak());
   }
 
   std::vector<llvm::SwitchInst::CaseHandle> cases{sw_inst->case_begin(),
@@ -496,20 +496,20 @@ clang::CompoundStmt *GenerateAST::StructureSwitchRegion(llvm::Region *region) {
     }
 
     auto value{ast_gen.CreateConstantExpr(sw_case.getCaseValue())};
-    auto case_stmt{ast.CreateCaseStmt(value)};
+    auto case_stmt{dec_ctx.ast.CreateCaseStmt(value)};
     if (successor != region->getExit()) {
       auto case_body{CreateBasicBlockStmts(successor)};
-      case_stmt->setSubStmt(ast.CreateCompoundStmt(case_body));
+      case_stmt->setSubStmt(dec_ctx.ast.CreateCompoundStmt(case_body));
       sw_body.push_back(case_stmt);
-      sw_body.push_back(ast.CreateBreak());
+      sw_body.push_back(dec_ctx.ast.CreateBreak());
     } else {
-      case_stmt->setSubStmt(ast.CreateBreak());
+      case_stmt->setSubStmt(dec_ctx.ast.CreateBreak());
       sw_body.push_back(case_stmt);
     }
   }
-  sw_stmt->setBody(ast.CreateCompoundStmt(sw_body));
+  sw_stmt->setBody(dec_ctx.ast.CreateCompoundStmt(sw_body));
   body.push_back(sw_stmt);
-  return ast.CreateCompoundStmt(body);
+  return dec_ctx.ast.CreateCompoundStmt(body);
 }
 
 clang::CompoundStmt *GenerateAST::StructureRegion(llvm::Region *region) {
@@ -630,7 +630,7 @@ GenerateAST::Result GenerateAST::run(llvm::Function &func,
   // Add declarations of local variables
   for (auto decl : fdecl->decls()) {
     if (clang::isa<clang::VarDecl>(decl)) {
-      fbody.push_back(ast.CreateDeclStmt(decl));
+      fbody.push_back(dec_ctx.ast.CreateDeclStmt(decl));
     }
   }
   // Add statements of the top-level region compound
@@ -638,7 +638,7 @@ GenerateAST::Result GenerateAST::run(llvm::Function &func,
     fbody.push_back(stmt);
   }
   // Set body to a new compound
-  fdefn->setBody(ast.CreateCompoundStmt(fbody));
+  fdefn->setBody(dec_ctx.ast.CreateCompoundStmt(fbody));
 
   return llvm::PreservedAnalyses::all();
 }

--- a/lib/AST/GenerateAST.cpp
+++ b/lib/AST/GenerateAST.cpp
@@ -336,11 +336,11 @@ StmtVec GenerateAST::CreateRegionStmts(llvm::Region *region) {
     } else {
       // Create a compound, wrapping the block
       auto block_body = CreateBasicBlockStmts(block);
-      compound = dec_ctx.ast.CreateCompoundStmt(block_body);
+      compound = ast.CreateCompoundStmt(block_body);
     }
     // Gate the compound behind a reaching condition
     auto z_expr{GetReachingCond(block)};
-    block_stmts[block] = dec_ctx.ast.CreateIf(dec_ctx.marker_expr, compound);
+    block_stmts[block] = ast.CreateIf(dec_ctx.marker_expr, compound);
     dec_ctx.conds[block_stmts[block]] =
         dec_ctx.InsertZExpr(dec_ctx.z3_exprs[z_expr]);
     // Store the compound
@@ -400,7 +400,7 @@ void GenerateAST::RefineLoopSuccessors(llvm::Loop *loop, BBSet &members,
 clang::CompoundStmt *GenerateAST::StructureAcyclicRegion(llvm::Region *region) {
   DLOG(INFO) << "Region " << GetRegionNameStr(region) << " is acyclic";
   auto region_body = CreateRegionStmts(region);
-  return dec_ctx.ast.CreateCompoundStmt(region_body);
+  return ast.CreateCompoundStmt(region_body);
 }
 
 clang::CompoundStmt *GenerateAST::StructureCyclicRegion(llvm::Region *region) {
@@ -413,7 +413,7 @@ clang::CompoundStmt *GenerateAST::StructureCyclicRegion(llvm::Region *region) {
   // a recognized natural loop. Cyclic regions may only be fragments
   // of a larger loop structure.
   if (!loop) {
-    return dec_ctx.ast.CreateCompoundStmt(region_body);
+    return ast.CreateCompoundStmt(region_body);
   }
   // Refine loop members and successors without invalidating LoopInfo
   BBSet members, successors;
@@ -447,9 +447,9 @@ clang::CompoundStmt *GenerateAST::StructureCyclicRegion(llvm::Region *region) {
     auto it = std::find(loop_body.begin(), loop_body.end(), block_stmts[from]);
     CHECK(it != loop_body.end());
     // Create a loop exiting `break` statement
-    StmtVec break_stmt({dec_ctx.ast.CreateBreak()});
-    auto exit_stmt = dec_ctx.ast.CreateIf(
-        dec_ctx.marker_expr, dec_ctx.ast.CreateCompoundStmt(break_stmt));
+    StmtVec break_stmt({ast.CreateBreak()});
+    auto exit_stmt =
+        ast.CreateIf(dec_ctx.marker_expr, ast.CreateCompoundStmt(break_stmt));
     // Create edge condition
     dec_ctx.conds[exit_stmt] = dec_ctx.InsertZExpr(
         (ToExpr(GetReachingCond(from)) && ToExpr(GetOrCreateEdgeCond(from, to)))
@@ -458,12 +458,12 @@ clang::CompoundStmt *GenerateAST::StructureCyclicRegion(llvm::Region *region) {
     loop_body.insert(std::next(it), exit_stmt);
   }
   // Create the loop statement
-  auto loop_stmt = dec_ctx.ast.CreateWhile(
-      dec_ctx.ast.CreateTrue(), dec_ctx.ast.CreateCompoundStmt(loop_body));
+  auto loop_stmt =
+      ast.CreateWhile(ast.CreateTrue(), ast.CreateCompoundStmt(loop_body));
   // Insert it at the beginning of the region body
   region_body.insert(region_body.begin(), loop_stmt);
   // Structure the rest of the loop body as a acyclic region
-  return dec_ctx.ast.CreateCompoundStmt(region_body);
+  return ast.CreateCompoundStmt(region_body);
 }
 
 clang::CompoundStmt *GenerateAST::StructureSwitchRegion(llvm::Region *region) {
@@ -475,15 +475,15 @@ clang::CompoundStmt *GenerateAST::StructureSwitchRegion(llvm::Region *region) {
   auto sw_inst{
       llvm::cast<llvm::SwitchInst>(region->getEntry()->getTerminator())};
   auto cond{ast_gen.CreateOperandExpr(sw_inst->getOperandUse(0))};
-  auto sw_stmt{dec_ctx.ast.CreateSwitchStmt(cond)};
+  auto sw_stmt{ast.CreateSwitchStmt(cond)};
   StmtVec sw_body;
 
   auto default_dest{sw_inst->getDefaultDest()};
   if (default_dest != region->getExit()) {
     auto default_body{CreateBasicBlockStmts(default_dest)};
-    sw_body.push_back(dec_ctx.ast.CreateDefaultStmt(
-        dec_ctx.ast.CreateCompoundStmt(default_body)));
-    sw_body.push_back(dec_ctx.ast.CreateBreak());
+    sw_body.push_back(
+        ast.CreateDefaultStmt(ast.CreateCompoundStmt(default_body)));
+    sw_body.push_back(ast.CreateBreak());
   }
 
   std::vector<llvm::SwitchInst::CaseHandle> cases{sw_inst->case_begin(),
@@ -496,20 +496,20 @@ clang::CompoundStmt *GenerateAST::StructureSwitchRegion(llvm::Region *region) {
     }
 
     auto value{ast_gen.CreateConstantExpr(sw_case.getCaseValue())};
-    auto case_stmt{dec_ctx.ast.CreateCaseStmt(value)};
+    auto case_stmt{ast.CreateCaseStmt(value)};
     if (successor != region->getExit()) {
       auto case_body{CreateBasicBlockStmts(successor)};
-      case_stmt->setSubStmt(dec_ctx.ast.CreateCompoundStmt(case_body));
+      case_stmt->setSubStmt(ast.CreateCompoundStmt(case_body));
       sw_body.push_back(case_stmt);
-      sw_body.push_back(dec_ctx.ast.CreateBreak());
+      sw_body.push_back(ast.CreateBreak());
     } else {
-      case_stmt->setSubStmt(dec_ctx.ast.CreateBreak());
+      case_stmt->setSubStmt(ast.CreateBreak());
       sw_body.push_back(case_stmt);
     }
   }
-  sw_stmt->setBody(dec_ctx.ast.CreateCompoundStmt(sw_body));
+  sw_stmt->setBody(ast.CreateCompoundStmt(sw_body));
   body.push_back(sw_stmt);
-  return dec_ctx.ast.CreateCompoundStmt(body);
+  return ast.CreateCompoundStmt(body);
 }
 
 clang::CompoundStmt *GenerateAST::StructureRegion(llvm::Region *region) {
@@ -630,7 +630,7 @@ GenerateAST::Result GenerateAST::run(llvm::Function &func,
   // Add declarations of local variables
   for (auto decl : fdecl->decls()) {
     if (clang::isa<clang::VarDecl>(decl)) {
-      fbody.push_back(dec_ctx.ast.CreateDeclStmt(decl));
+      fbody.push_back(ast.CreateDeclStmt(decl));
     }
   }
   // Add statements of the top-level region compound
@@ -638,7 +638,7 @@ GenerateAST::Result GenerateAST::run(llvm::Function &func,
     fbody.push_back(stmt);
   }
   // Set body to a new compound
-  fdefn->setBody(dec_ctx.ast.CreateCompoundStmt(fbody));
+  fdefn->setBody(ast.CreateCompoundStmt(fbody));
 
   return llvm::PreservedAnalyses::all();
 }

--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -86,8 +86,8 @@ clang::Expr *IRToASTVisitor::ConvertExpr(z3::expr expr) {
 
     for (auto sw_case : inst->cases()) {
       if (sw_case.getCaseIndex() == case_idx) {
-        return dec_ctx.ast.CreateEQ(CreateOperandExpr(inst->getOperandUse(0)),
-                                    CreateConstantExpr(sw_case.getCaseValue()));
+        return ast.CreateEQ(CreateOperandExpr(inst->getOperandUse(0)),
+                            CreateConstantExpr(sw_case.getCaseValue()));
       }
     }
 
@@ -111,31 +111,31 @@ clang::Expr *IRToASTVisitor::ConvertExpr(z3::expr expr) {
   switch (expr.decl().decl_kind()) {
     case Z3_OP_TRUE:
       CHECK_EQ(expr.num_args(), 0) << "True cannot have arguments";
-      return dec_ctx.ast.CreateTrue();
+      return ast.CreateTrue();
     case Z3_OP_FALSE:
       CHECK_EQ(expr.num_args(), 0) << "False cannot have arguments";
-      return dec_ctx.ast.CreateFalse();
+      return ast.CreateFalse();
     case Z3_OP_AND: {
       // Since AND and OR expressions are n-ary we need to convert them to
       // binary. If they have only one subexpression, we can forego the AND/OR
       // altogether.
       clang::Expr *res{ConvertExpr(expr.arg(0))};
       for (auto i{1U}; i < expr.num_args(); ++i) {
-        res = dec_ctx.ast.CreateLAnd(res, ConvertExpr(expr.arg(i)));
+        res = ast.CreateLAnd(res, ConvertExpr(expr.arg(i)));
       }
       return res;
     }
     case Z3_OP_OR: {
       clang::Expr *res{ConvertExpr(expr.arg(0))};
       for (auto i{1U}; i < expr.num_args(); ++i) {
-        res = dec_ctx.ast.CreateLOr(res, ConvertExpr(expr.arg(i)));
+        res = ast.CreateLOr(res, ConvertExpr(expr.arg(i)));
       }
       return res;
     }
     case Z3_OP_NOT: {
       CHECK_EQ(expr.num_args(), 1) << "Not must have one argument";
       auto sub{ConvertExpr(expr.arg(0))};
-      auto neg{dec_ctx.ast.CreateLNot(sub)};
+      auto neg{ast.CreateLNot(sub)};
       CopyProvenance(sub, neg, dec_ctx.use_provenance);
       return neg;
     }
@@ -160,14 +160,14 @@ void ExprGen::VisitGlobalVar(llvm::GlobalVariable &gvar) {
   }
 
   auto type{dec_ctx.type_provider->GetGlobalVarType(gvar)};
-  auto tudecl{dec_ctx.ast_ctx.getTranslationUnitDecl()};
+  auto tudecl{ast_ctx.getTranslationUnitDecl()};
   auto name{gvar.getName().str()};
   if (name.empty()) {
     name = "gvar" + std::to_string(GetNumDecls<clang::VarDecl>(tudecl));
   }
 
   // Create a variable declaration
-  var = dec_ctx.ast.CreateVarDecl(tudecl, type, name);
+  var = ast.CreateVarDecl(tudecl, type, name);
   // Add to translation unit
   tudecl->addDecl(var);
 
@@ -196,8 +196,8 @@ clang::Expr *ExprGen::CreateConstantExpr(llvm::Constant *constant) {
     return CreateConstantExpr(alias->getAliasee());
   } else if (auto global = llvm::dyn_cast<llvm::GlobalValue>(constant)) {
     auto decl{dec_ctx.value_decls[global]};
-    auto ref{dec_ctx.ast.CreateDeclRef(decl)};
-    return dec_ctx.ast.CreateAddrOf(ref);
+    auto ref{ast.CreateDeclRef(decl)};
+    return ast.CreateAddrOf(ref);
   }
   return CreateLiteralExpr(constant);
 }
@@ -217,7 +217,7 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
         init_exprs.push_back(CreateConstantExpr(elm));
       }
     }
-    return dec_ctx.ast.CreateInitList(init_exprs);
+    return ast.CreateInitList(init_exprs);
   }};
 
   switch (l_type->getTypeID()) {
@@ -226,7 +226,7 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
     case llvm::Type::FloatTyID:
     case llvm::Type::DoubleTyID:
     case llvm::Type::X86_FP80TyID: {
-      result = dec_ctx.ast.CreateFPLit(
+      result = ast.CreateFPLit(
           llvm::cast<llvm::ConstantFP>(constant)->getValueAPF());
     } break;
     // Integers
@@ -234,27 +234,24 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
       if (llvm::isa<llvm::ConstantInt>(constant)) {
         auto val{llvm::cast<llvm::ConstantInt>(constant)->getValue()};
         auto val_bitwidth{val.getBitWidth()};
-        auto ull_bitwidth{
-            dec_ctx.ast_ctx.getIntWidth(dec_ctx.ast_ctx.LongLongTy)};
+        auto ull_bitwidth{ast_ctx.getIntWidth(ast_ctx.LongLongTy)};
         if (val_bitwidth == 1U) {
           // Booleans
-          result = dec_ctx.ast.CreateIntLit(val);
+          result = ast.CreateIntLit(val);
         } else if (val.getActiveBits() <= ull_bitwidth) {
-          result = dec_ctx.ast.CreateAdjustedIntLit(val);
+          result = ast.CreateAdjustedIntLit(val);
         } else {
           // Values wider than `long long` will be represented as:
           // (uint128_t)hi_64 << 64U | lo_64
-          auto lo{dec_ctx.ast.CreateIntLit(val.extractBits(64U, 0U))};
-          auto hi{dec_ctx.ast.CreateIntLit(
-              val.extractBits(val_bitwidth - 64U, 64U))};
-          auto shl_val{dec_ctx.ast.CreateIntLit(llvm::APInt(32U, 64U))};
-          result = dec_ctx.ast.CreateCStyleCast(
-              dec_ctx.ast_ctx.UnsignedInt128Ty, hi);
-          result = dec_ctx.ast.CreateShl(result, shl_val);
-          result = dec_ctx.ast.CreateOr(result, lo);
+          auto lo{ast.CreateIntLit(val.extractBits(64U, 0U))};
+          auto hi{ast.CreateIntLit(val.extractBits(val_bitwidth - 64U, 64U))};
+          auto shl_val{ast.CreateIntLit(llvm::APInt(32U, 64U))};
+          result = ast.CreateCStyleCast(ast_ctx.UnsignedInt128Ty, hi);
+          result = ast.CreateShl(result, shl_val);
+          result = ast.CreateOr(result, lo);
         }
       } else if (llvm::isa<llvm::UndefValue>(constant)) {
-        result = dec_ctx.ast.CreateUndefInteger(c_type);
+        result = ast.CreateUndefInteger(c_type);
       } else {
         THROW() << "Unsupported integer constant";
       }
@@ -262,9 +259,9 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
     // Pointers
     case llvm::Type::PointerTyID: {
       if (llvm::isa<llvm::ConstantPointerNull>(constant)) {
-        result = dec_ctx.ast.CreateNull();
+        result = ast.CreateNull();
       } else if (llvm::isa<llvm::UndefValue>(constant)) {
-        result = dec_ctx.ast.CreateUndefPointer(c_type);
+        result = ast.CreateUndefPointer(c_type);
       } else {
         THROW() << "Unsupported pointer constant";
       }
@@ -277,7 +274,7 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
         if (auto arr = llvm::dyn_cast<llvm::ConstantDataArray>(constant)) {
           init = arr->getAsString().str();
         }
-        result = dec_ctx.ast.CreateStrLit(init);
+        result = ast.CreateStrLit(init);
       } else {
         result = CreateInitListLiteral();
       }
@@ -290,7 +287,7 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
     default: {
       // Vectors
       if (l_type->isVectorTy()) {
-        result = dec_ctx.ast.CreateCompoundLit(c_type, CreateInitListLiteral());
+        result = ast.CreateCompoundLit(c_type, CreateInitListLiteral());
       } else {
         THROW() << "Unknown LLVM constant type: " << LLVMThingToString(l_type);
       }
@@ -309,7 +306,7 @@ clang::Expr *ExprGen::CreateOperandExpr(llvm::Use &val) {
   DLOG(INFO) << "Getting Expr for " << LLVMThingToString(val);
   auto CreateRef{[this, &val] {
     auto decl{dec_ctx.value_decls[val]};
-    auto ref{dec_ctx.ast.CreateDeclRef(decl)};
+    auto ref{ast.CreateDeclRef(decl)};
     dec_ctx.use_provenance[ref] = &val;
     return ref;
   }};
@@ -321,7 +318,7 @@ clang::Expr *ExprGen::CreateOperandExpr(llvm::Use &val) {
   } else if (llvm::isa<llvm::AllocaInst>(val)) {
     // Operand is an l-value (variable, function, ...)
     // Add a `&` operator
-    res = dec_ctx.ast.CreateAddrOf(CreateRef());
+    res = ast.CreateAddrOf(CreateRef());
   } else if (llvm::isa<llvm::Argument>(val)) {
     // Operand is a function argument or local variable
     auto arg{llvm::cast<llvm::Argument>(val)};
@@ -334,25 +331,24 @@ clang::Expr *ExprGen::CreateOperandExpr(llvm::Use &val) {
       // arguments assume they are dealing with pointers.
       auto &temp{dec_ctx.temp_decls[arg]};
       if (!temp) {
-        auto addr_of_arg{dec_ctx.ast.CreateAddrOf(ref)};
+        auto addr_of_arg{ast.CreateAddrOf(ref)};
         auto func{arg->getParent()};
         auto fdecl{dec_ctx.value_decls[func]->getAsFunction()};
         auto argdecl{clang::cast<clang::ParmVarDecl>(dec_ctx.value_decls[arg])};
-        temp = dec_ctx.ast.CreateVarDecl(fdecl,
-                                         dec_ctx.GetQualType(arg->getType()),
-                                         argdecl->getName().str() + "_ptr");
+        temp = ast.CreateVarDecl(fdecl, dec_ctx.GetQualType(arg->getType()),
+                                 argdecl->getName().str() + "_ptr");
         temp->setInit(addr_of_arg);
         fdecl->addDecl(temp);
       }
 
-      res = dec_ctx.ast.CreateDeclRef(temp);
+      res = ast.CreateDeclRef(temp);
     } else {
       res = ref;
     }
   } else if (auto inst = llvm::dyn_cast<llvm::Instruction>(val)) {
     // Operand is a result of an expression
     if (auto decl = dec_ctx.value_decls[inst]) {
-      res = dec_ctx.ast.CreateDeclRef(decl);
+      res = ast.CreateDeclRef(decl);
     } else {
       res = visit(inst);
     }
@@ -385,8 +381,7 @@ clang::Expr *ExprGen::visitMemCpyInst(llvm::MemCpyInst &inst) {
     args.push_back(CreateOperandExpr(arg));
   }
 
-  return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy,
-                                       args);
+  return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy, args);
 }
 
 clang::Expr *ExprGen::visitMemCpyInlineInst(llvm::MemCpyInlineInst &inst) {
@@ -398,8 +393,7 @@ clang::Expr *ExprGen::visitMemCpyInlineInst(llvm::MemCpyInlineInst &inst) {
     args.push_back(CreateOperandExpr(arg));
   }
 
-  return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy,
-                                       args);
+  return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy, args);
 }
 
 clang::Expr *ExprGen::visitAnyMemMoveInst(llvm::AnyMemMoveInst &inst) {
@@ -411,8 +405,7 @@ clang::Expr *ExprGen::visitAnyMemMoveInst(llvm::AnyMemMoveInst &inst) {
     args.push_back(CreateOperandExpr(arg));
   }
 
-  return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memmove,
-                                       args);
+  return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memmove, args);
 }
 
 clang::Expr *ExprGen::visitAnyMemSetInst(llvm::AnyMemSetInst &inst) {
@@ -424,8 +417,7 @@ clang::Expr *ExprGen::visitAnyMemSetInst(llvm::AnyMemSetInst &inst) {
     args.push_back(CreateOperandExpr(arg));
   }
 
-  return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memset,
-                                       args);
+  return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memset, args);
 }
 
 clang::Expr *ExprGen::visitIntrinsicInst(llvm::IntrinsicInst &inst) {
@@ -462,10 +454,9 @@ clang::Expr *ExprGen::visitCallInst(llvm::CallInst &inst) {
     auto &arg{inst.getArgOperandUse(i)};
     auto opnd{CreateOperandExpr(arg)};
     if (inst.getParamAttr(i, llvm::Attribute::ByVal).isValid()) {
-      auto ptr_type{dec_ctx.ast_ctx.getPointerType(
+      auto ptr_type{ast_ctx.getPointerType(
           dec_ctx.GetQualType(inst.getParamByValType(i)))};
-      opnd =
-          dec_ctx.ast.CreateDeref(dec_ctx.ast.CreateCStyleCast(ptr_type, opnd));
+      opnd = ast.CreateDeref(ast.CreateCStyleCast(ptr_type, opnd));
       dec_ctx.use_provenance[opnd] = &arg;
     }
     args.push_back(opnd);
@@ -476,23 +467,23 @@ clang::Expr *ExprGen::visitCallInst(llvm::CallInst &inst) {
   if (auto func = llvm::dyn_cast<llvm::Function>(callee)) {
     auto fdecl{dec_ctx.value_decls[func]->getAsFunction()};
     if (func->getFunctionType() == inst.getFunctionType()) {
-      callexpr = dec_ctx.ast.CreateCall(fdecl, args);
+      callexpr = ast.CreateCall(fdecl, args);
     } else {
       // Cast function type to match the one used in the call instruction
-      auto funcPtr{dec_ctx.ast_ctx.getPointerType(
-          dec_ctx.GetQualType(inst.getFunctionType()))};
-      auto callee{dec_ctx.ast.CreateAddrOf(dec_ctx.ast.CreateDeclRef(fdecl))};
-      auto cast{dec_ctx.ast.CreateCStyleCast(funcPtr, callee)};
-      callexpr = dec_ctx.ast.CreateCall(cast, args);
+      auto funcPtr{
+          ast_ctx.getPointerType(dec_ctx.GetQualType(inst.getFunctionType()))};
+      auto callee{ast.CreateAddrOf(ast.CreateDeclRef(fdecl))};
+      auto cast{ast.CreateCStyleCast(funcPtr, callee)};
+      callexpr = ast.CreateCall(cast, args);
     }
   } else if (auto iasm = llvm::dyn_cast<llvm::InlineAsm>(callee)) {
     auto fdecl{dec_ctx.value_decls[iasm]->getAsFunction()};
-    callexpr = dec_ctx.ast.CreateCall(fdecl, args);
+    callexpr = ast.CreateCall(fdecl, args);
   } else if (llvm::isa<llvm::PointerType>(callee->getType())) {
-    auto funcPtr{dec_ctx.ast_ctx.getPointerType(
-        dec_ctx.GetQualType(inst.getFunctionType()))};
-    auto cast{dec_ctx.ast.CreateCStyleCast(funcPtr, CreateOperandExpr(callee))};
-    callexpr = dec_ctx.ast.CreateCall(cast, args);
+    auto funcPtr{
+        ast_ctx.getPointerType(dec_ctx.GetQualType(inst.getFunctionType()))};
+    auto cast{ast.CreateCStyleCast(funcPtr, CreateOperandExpr(callee))};
+    callexpr = ast.CreateCall(cast, args);
   } else {
     LOG(FATAL) << "Callee is not a function";
   }
@@ -560,14 +551,14 @@ clang::Expr *ExprGen::visitGetElementPtrInst(llvm::GetElementPtrInst &inst) {
   if (is_string_access()) {
     auto gvar{llvm::cast<llvm::GlobalVariable>(ptr_opnd)};
     auto arr{llvm::cast<llvm::ConstantDataArray>(gvar->getInitializer())};
-    return dec_ctx.ast.CreateStrLit(arr->getAsString().str().c_str());
+    return ast.CreateStrLit(arr->getAsString().str().c_str());
   }
 
   auto base{CreateOperandExpr(ptr_opnd)};
 
-  auto ptr_type{dec_ctx.ast_ctx.getPointerType(
-      dec_ctx.GetQualType(inst.getSourceElementType()))};
-  base = dec_ctx.ast.CreateCStyleCast(ptr_type, base);
+  auto ptr_type{
+      ast_ctx.getPointerType(dec_ctx.GetQualType(inst.getSourceElementType()))};
+  base = ast.CreateCStyleCast(ptr_type, base);
 
   for (auto &idx : llvm::make_range(inst.idx_begin(), inst.idx_end())) {
     dec_ctx.GetQualType(indexed_type);
@@ -576,14 +567,14 @@ clang::Expr *ExprGen::visitGetElementPtrInst(llvm::GetElementPtrInst &inst) {
       case llvm::Type::PointerTyID: {
         CHECK(idx == *inst.idx_begin())
             << "Indexing an llvm::PointerType is only valid at first index";
-        base = dec_ctx.ast.CreateArraySub(base, CreateOperandExpr(idx));
+        base = ast.CreateArraySub(base, CreateOperandExpr(idx));
         std::vector<uint64_t> indices({0});
         indexed_type = llvm::GetElementPtrInst::getIndexedType(
             inst.getSourceElementType(), indices);
       } break;
       // Arrays
       case llvm::Type::ArrayTyID: {
-        base = dec_ctx.ast.CreateArraySub(base, CreateOperandExpr(idx));
+        base = ast.CreateArraySub(base, CreateOperandExpr(idx));
         indexed_type =
             llvm::cast<llvm::ArrayType>(indexed_type)->getElementType();
       } break;
@@ -597,7 +588,7 @@ clang::Expr *ExprGen::visitGetElementPtrInst(llvm::GetElementPtrInst &inst) {
         auto field_it{record->field_begin()};
         std::advance(field_it, mem_idx->getLimitedValue());
         CHECK(field_it != record->field_end()) << "GEP index is out of bounds";
-        base = dec_ctx.ast.CreateDot(base, *field_it);
+        base = ast.CreateDot(base, *field_it);
         indexed_type =
             llvm::cast<llvm::StructType>(indexed_type)->getTypeAtIndex(idx);
       } break;
@@ -608,10 +599,9 @@ clang::Expr *ExprGen::visitGetElementPtrInst(llvm::GetElementPtrInst &inst) {
           auto l_vec_ty{llvm::cast<llvm::VectorType>(indexed_type)};
           auto l_elm_ty{l_vec_ty->getElementType()};
           auto c_elm_ty{dec_ctx.GetQualType(l_elm_ty)};
-          base = dec_ctx.ast.CreateCStyleCast(
-              dec_ctx.ast_ctx.getPointerType(c_elm_ty),
-              dec_ctx.ast.CreateAddrOf(base));
-          base = dec_ctx.ast.CreateArraySub(base, CreateOperandExpr(idx));
+          base = ast.CreateCStyleCast(ast_ctx.getPointerType(c_elm_ty),
+                                      ast.CreateAddrOf(base));
+          base = ast.CreateArraySub(base, CreateOperandExpr(idx));
           indexed_type = l_elm_ty;
         } else {
           THROW() << "Indexing an unknown type: "
@@ -621,7 +611,7 @@ clang::Expr *ExprGen::visitGetElementPtrInst(llvm::GetElementPtrInst &inst) {
     }
   }
 
-  return dec_ctx.ast.CreateAddrOf(base);
+  return ast.CreateAddrOf(base);
 }
 
 clang::Expr *ExprGen::visitInstruction(llvm::Instruction &inst) {
@@ -635,8 +625,7 @@ clang::Expr *ExprGen::visitExtractValueInst(llvm::ExtractValueInst &inst) {
   auto base{CreateOperandExpr(inst.getOperandUse(0))};
   auto indexed_type{inst.getAggregateOperand()->getType()};
   if (clang::isa<clang::InitListExpr>(base)) {
-    base =
-        dec_ctx.ast.CreateCompoundLit(dec_ctx.GetQualType(indexed_type), base);
+    base = ast.CreateCompoundLit(dec_ctx.GetQualType(indexed_type), base);
   }
 
   for (auto idx : llvm::make_range(inst.idx_begin(), inst.idx_end())) {
@@ -644,9 +633,8 @@ clang::Expr *ExprGen::visitExtractValueInst(llvm::ExtractValueInst &inst) {
     switch (indexed_type->getTypeID()) {
       // Arrays
       case llvm::Type::ArrayTyID: {
-        base = dec_ctx.ast.CreateArraySub(
-            base,
-            dec_ctx.ast.CreateIntLit(llvm::APInt(sizeof(unsigned) * 8U, idx)));
+        base = ast.CreateArraySub(
+            base, ast.CreateIntLit(llvm::APInt(sizeof(unsigned) * 8U, idx)));
         indexed_type =
             llvm::cast<llvm::ArrayType>(indexed_type)->getElementType();
       } break;
@@ -659,7 +647,7 @@ clang::Expr *ExprGen::visitExtractValueInst(llvm::ExtractValueInst &inst) {
         std::advance(field_it, idx);
         CHECK(field_it != record->field_end())
             << "ExtractValue index is out of bounds";
-        base = dec_ctx.ast.CreateDot(base, *field_it);
+        base = ast.CreateDot(base, *field_it);
         indexed_type =
             llvm::cast<llvm::StructType>(indexed_type)->getTypeAtIndex(idx);
       } break;
@@ -675,11 +663,10 @@ clang::Expr *ExprGen::visitExtractValueInst(llvm::ExtractValueInst &inst) {
 
 clang::Expr *ExprGen::visitLoadInst(llvm::LoadInst &inst) {
   DLOG(INFO) << "visitLoadInst: " << LLVMThingToString(&inst);
-  auto ptr_type{
-      dec_ctx.ast_ctx.getPointerType(dec_ctx.GetQualType(inst.getType()))};
-  auto cast{dec_ctx.ast.CreateCStyleCast(
-      ptr_type, CreateOperandExpr(inst.getOperandUse(0)))};
-  return dec_ctx.ast.CreateDeref(cast);
+  auto ptr_type{ast_ctx.getPointerType(dec_ctx.GetQualType(inst.getType()))};
+  auto cast{
+      ast.CreateCStyleCast(ptr_type, CreateOperandExpr(inst.getOperandUse(0)))};
+  return ast.CreateDeref(cast);
 }
 
 clang::Expr *ExprGen::visitBinaryOperator(llvm::BinaryOperator &inst) {
@@ -689,76 +676,72 @@ clang::Expr *ExprGen::visitBinaryOperator(llvm::BinaryOperator &inst) {
   auto rhs{CreateOperandExpr(inst.getOperandUse(1))};
   // Sign-cast int operand
   auto IntSignCast{[this](clang::Expr *operand, bool sign) {
-    auto type{dec_ctx.ast_ctx.getIntTypeForBitwidth(
-        dec_ctx.ast_ctx.getTypeSize(operand->getType()), sign)};
-    return dec_ctx.ast.CreateCStyleCast(type, operand);
+    auto type{ast_ctx.getIntTypeForBitwidth(
+        ast_ctx.getTypeSize(operand->getType()), sign)};
+    return ast.CreateCStyleCast(type, operand);
   }};
   clang::Expr *res;
   // Where the magic happens
   switch (inst.getOpcode()) {
     case llvm::BinaryOperator::LShr:
-      res = dec_ctx.ast.CreateShr(IntSignCast(lhs, false), rhs);
+      res = ast.CreateShr(IntSignCast(lhs, false), rhs);
       break;
 
     case llvm::BinaryOperator::AShr:
-      res = dec_ctx.ast.CreateShr(IntSignCast(lhs, true), rhs);
+      res = ast.CreateShr(IntSignCast(lhs, true), rhs);
       break;
 
     case llvm::BinaryOperator::Shl:
-      res = dec_ctx.ast.CreateShl(lhs, rhs);
+      res = ast.CreateShl(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::And:
-      res = inst.getType()->isIntegerTy(1U) ? dec_ctx.ast.CreateLAnd(lhs, rhs)
-                                            : dec_ctx.ast.CreateAnd(lhs, rhs);
+      res = inst.getType()->isIntegerTy(1U) ? ast.CreateLAnd(lhs, rhs)
+                                            : ast.CreateAnd(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::Or:
-      res = inst.getType()->isIntegerTy(1U) ? dec_ctx.ast.CreateLOr(lhs, rhs)
-                                            : dec_ctx.ast.CreateOr(lhs, rhs);
+      res = inst.getType()->isIntegerTy(1U) ? ast.CreateLOr(lhs, rhs)
+                                            : ast.CreateOr(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::Xor:
-      res = dec_ctx.ast.CreateXor(lhs, rhs);
+      res = ast.CreateXor(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::URem:
-      res = dec_ctx.ast.CreateRem(IntSignCast(lhs, false),
-                                  IntSignCast(rhs, false));
+      res = ast.CreateRem(IntSignCast(lhs, false), IntSignCast(rhs, false));
       break;
 
     case llvm::BinaryOperator::SRem:
-      res =
-          dec_ctx.ast.CreateRem(IntSignCast(lhs, true), IntSignCast(rhs, true));
+      res = ast.CreateRem(IntSignCast(lhs, true), IntSignCast(rhs, true));
       break;
 
     case llvm::BinaryOperator::UDiv:
-      res = dec_ctx.ast.CreateDiv(IntSignCast(lhs, false),
-                                  IntSignCast(rhs, false));
+      res = ast.CreateDiv(IntSignCast(lhs, false), IntSignCast(rhs, false));
       break;
 
     case llvm::BinaryOperator::SDiv:
-      res =
-          dec_ctx.ast.CreateDiv(IntSignCast(lhs, true), IntSignCast(rhs, true));
+      res = ast.CreateDiv(IntSignCast(lhs, true), IntSignCast(rhs, true));
       break;
 
     case llvm::BinaryOperator::FDiv:
-      res = dec_ctx.ast.CreateDiv(lhs, rhs);
+      res = ast.CreateDiv(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::Add:
     case llvm::BinaryOperator::FAdd:
-      res = dec_ctx.ast.CreateAdd(lhs, rhs);
+      res = ast.CreateAdd(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::Sub:
     case llvm::BinaryOperator::FSub:
-      res = dec_ctx.ast.CreateSub(lhs, rhs);
+      res = ast.CreateSub(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::Mul:
     case llvm::BinaryOperator::FMul:
-      res = dec_ctx.ast.CreateMul(lhs, rhs);
+      res = ast.CreateMul(lhs, rhs);
       break;
 
     default:
@@ -776,12 +759,11 @@ clang::Expr *ExprGen::visitCmpInst(llvm::CmpInst &inst) {
   // Sign-cast int operand
   auto IntSignCast{[this](clang::Expr *op, bool sign) {
     auto ot{op->getType()};
-    auto rt{dec_ctx.ast_ctx.getIntTypeForBitwidth(
-        dec_ctx.ast_ctx.getTypeSize(ot), sign)};
+    auto rt{ast_ctx.getIntTypeForBitwidth(ast_ctx.getTypeSize(ot), sign)};
     if (rt == ot) {
       return op;
     } else {
-      auto cast{dec_ctx.ast.CreateCStyleCast(rt, op)};
+      auto cast{ast.CreateCStyleCast(rt, op)};
       CopyProvenance(op, cast, dec_ctx.use_provenance);
       return (clang::Expr *)cast;
     }
@@ -803,72 +785,70 @@ clang::Expr *ExprGen::visitCmpInst(llvm::CmpInst &inst) {
     case llvm::CmpInst::ICMP_UGT:
     case llvm::CmpInst::ICMP_SGT:
     case llvm::CmpInst::FCMP_OGT:
-      res = dec_ctx.ast.CreateGT(lhs, rhs);
+      res = ast.CreateGT(lhs, rhs);
       break;
 
     case llvm::CmpInst::ICMP_ULT:
     case llvm::CmpInst::ICMP_SLT:
     case llvm::CmpInst::FCMP_OLT:
-      res = dec_ctx.ast.CreateLT(lhs, rhs);
+      res = ast.CreateLT(lhs, rhs);
       break;
 
     case llvm::CmpInst::ICMP_UGE:
     case llvm::CmpInst::ICMP_SGE:
     case llvm::CmpInst::FCMP_OGE:
-      res = dec_ctx.ast.CreateGE(lhs, rhs);
+      res = ast.CreateGE(lhs, rhs);
       break;
 
     case llvm::CmpInst::ICMP_ULE:
     case llvm::CmpInst::ICMP_SLE:
     case llvm::CmpInst::FCMP_OLE:
-      res = dec_ctx.ast.CreateLE(lhs, rhs);
+      res = ast.CreateLE(lhs, rhs);
       break;
 
     case llvm::CmpInst::ICMP_EQ:
     case llvm::CmpInst::FCMP_OEQ:
-      res = dec_ctx.ast.CreateEQ(lhs, rhs);
+      res = ast.CreateEQ(lhs, rhs);
       break;
 
     case llvm::CmpInst::ICMP_NE:
-      res = dec_ctx.ast.CreateNE(lhs, rhs);
+      res = ast.CreateNE(lhs, rhs);
       break;
 
     case llvm::CmpInst::FCMP_UGT:
-      res = dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isgreater,
-                                          args);
+      res = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isgreater, args);
       break;
 
     case llvm::CmpInst::FCMP_ULT:
-      res = dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isless,
-                                          args);
+      res = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isless, args);
       break;
 
     case llvm::CmpInst::FCMP_UGE:
-      res = dec_ctx.ast.CreateBuiltinCall(
-          clang::Builtin::BI__builtin_isgreaterequal, args);
+      res = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isgreaterequal,
+                                  args);
       break;
 
     case llvm::CmpInst::FCMP_ULE:
-      res = dec_ctx.ast.CreateBuiltinCall(
-          clang::Builtin::BI__builtin_islessequal, args);
+      res =
+          ast.CreateBuiltinCall(clang::Builtin::BI__builtin_islessequal, args);
       break;
 
     case llvm::CmpInst::FCMP_UNE:
-      res = dec_ctx.ast.CreateBuiltinCall(
-          clang::Builtin::BI__builtin_islessgreater, args);
+      res = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_islessgreater,
+                                  args);
       break;
 
     case llvm::CmpInst::FCMP_UNO:
-      res = dec_ctx.ast.CreateBuiltinCall(
-          clang::Builtin::BI__builtin_isunordered, args);
+      res =
+          ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isunordered, args);
       break;
 
     case llvm::CmpInst::FCMP_TRUE:
-      res = dec_ctx.ast.CreateTrue();
+      res = ast.CreateTrue();
       break;
 
     case llvm::CmpInst::FCMP_FALSE:
-      res = dec_ctx.ast.CreateFalse();
+      res = ast.CreateFalse();
       break;
 
     default:
@@ -888,19 +868,19 @@ clang::Expr *ExprGen::visitCastInst(llvm::CastInst &inst) {
   // Adjust type
   switch (inst.getOpcode()) {
     case llvm::CastInst::Trunc: {
-      auto bitwidth{dec_ctx.ast_ctx.getTypeSize(type)};
+      auto bitwidth{ast_ctx.getTypeSize(type)};
       auto sign{operand->getType()->isSignedIntegerType()};
-      type = dec_ctx.ast_ctx.getIntTypeForBitwidth(bitwidth, sign);
+      type = ast_ctx.getIntTypeForBitwidth(bitwidth, sign);
     } break;
 
     case llvm::CastInst::ZExt: {
-      auto bitwidth{dec_ctx.ast_ctx.getTypeSize(type)};
-      type = dec_ctx.ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/0U);
+      auto bitwidth{ast_ctx.getTypeSize(type)};
+      type = ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/0U);
     } break;
 
     case llvm::CastInst::SExt: {
-      auto bitwidth{dec_ctx.ast_ctx.getTypeSize(type)};
-      type = dec_ctx.ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/1U);
+      auto bitwidth{ast_ctx.getTypeSize(type)};
+      type = ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/1U);
     } break;
 
     case llvm::CastInst::AddrSpaceCast:
@@ -928,7 +908,7 @@ clang::Expr *ExprGen::visitCastInst(llvm::CastInst &inst) {
     } break;
   }
   // Create cast
-  return dec_ctx.ast.CreateCStyleCast(type, operand);
+  return ast.CreateCStyleCast(type, operand);
 }
 
 clang::Expr *ExprGen::visitSelectInst(llvm::SelectInst &inst) {
@@ -938,7 +918,7 @@ clang::Expr *ExprGen::visitSelectInst(llvm::SelectInst &inst) {
   auto tval{CreateOperandExpr(inst.getOperandUse(1))};
   auto fval{CreateOperandExpr(inst.getOperandUse(2))};
 
-  return dec_ctx.ast.CreateConditional(cond, tval, fval);
+  return ast.CreateConditional(cond, tval, fval);
 }
 
 clang::Expr *ExprGen::visitFreezeInst(llvm::FreezeInst &inst) {
@@ -954,7 +934,7 @@ clang::Expr *ExprGen::visitUnaryOperator(llvm::UnaryOperator &inst) {
       << "Unsupported UnaryOperator: " << LLVMThingToString(&inst);
 
   auto opnd{CreateOperandExpr(inst.getOperandUse(0))};
-  return dec_ctx.ast.CreateUnaryOp(clang::UO_Minus, opnd);
+  return ast.CreateUnaryOp(clang::UO_Minus, opnd);
 }
 
 // StmtGen is tasked with populating blocks with their top-level
@@ -998,9 +978,9 @@ clang::Stmt *StmtGen::visitStoreInst(llvm::StoreInst &inst) {
   auto &value_opnd{inst.getOperandUse(0)};
   // Stores in LLVM IR correspond to value assignments in C
   // Get the operand we're assigning to
-  auto ptr_type{dec_ctx.ast_ctx.getPointerType(
-      dec_ctx.GetQualType(value_opnd->getType()))};
-  auto lhs{dec_ctx.ast.CreateCStyleCast(
+  auto ptr_type{
+      ast_ctx.getPointerType(dec_ctx.GetQualType(value_opnd->getType()))};
+  auto lhs{ast.CreateCStyleCast(
       ptr_type, expr_gen.CreateOperandExpr(
                     inst.getOperandUse(inst.getPointerOperandIndex())))};
   if (auto undef = llvm::dyn_cast<llvm::UndefValue>(value_opnd)) {
@@ -1013,23 +993,20 @@ clang::Stmt *StmtGen::visitStoreInst(llvm::StoreInst &inst) {
     // instead
     auto DL{inst.getModule()->getDataLayout()};
     llvm::APInt sz(64, DL.getTypeAllocSize(value_opnd->getType()));
-    auto sz_expr{dec_ctx.ast.CreateIntLit(sz)};
+    auto sz_expr{ast.CreateIntLit(sz)};
     if (llvm::isa<llvm::ConstantAggregateZero>(value_opnd)) {
       llvm::APInt zero(8, 0, false);
-      std::vector<clang::Expr *> args{lhs, dec_ctx.ast.CreateIntLit(zero),
-                                      sz_expr};
-      return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memset,
-                                           args);
+      std::vector<clang::Expr *> args{lhs, ast.CreateIntLit(zero), sz_expr};
+      return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memset, args);
     } else {
       std::vector<clang::Expr *> args{lhs, rhs, sz_expr};
-      return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy,
-                                           args);
+      return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy, args);
     }
   } else {
     // Create the assignemnt itself
-    auto deref{dec_ctx.ast.CreateDeref(lhs)};
+    auto deref{ast.CreateDeref(lhs)};
     CopyProvenance(lhs, deref, dec_ctx.use_provenance);
-    return dec_ctx.ast.CreateAssign(deref, rhs);
+    return ast.CreateAssign(deref, rhs);
   }
 }
 
@@ -1037,7 +1014,7 @@ clang::Stmt *StmtGen::visitCallInst(llvm::CallInst &inst) {
   auto &var{dec_ctx.value_decls[&inst]};
   auto expr{expr_gen.visit(inst)};
   if (var) {
-    return dec_ctx.ast.CreateAssign(dec_ctx.ast.CreateDeclRef(var), expr);
+    return ast.CreateAssign(ast.CreateDeclRef(var), expr);
   }
   return expr;
 }
@@ -1045,10 +1022,9 @@ clang::Stmt *StmtGen::visitCallInst(llvm::CallInst &inst) {
 clang::Stmt *StmtGen::visitReturnInst(llvm::ReturnInst &inst) {
   DLOG(INFO) << "visitReturnInst: " << LLVMThingToString(&inst);
   if (auto retval = inst.getReturnValue()) {
-    return dec_ctx.ast.CreateReturn(
-        expr_gen.CreateOperandExpr(inst.getOperandUse(0)));
+    return ast.CreateReturn(expr_gen.CreateOperandExpr(inst.getOperandUse(0)));
   } else {
-    return dec_ctx.ast.CreateReturn();
+    return ast.CreateReturn();
   }
 }
 
@@ -1079,7 +1055,7 @@ clang::Stmt *StmtGen::visitInstruction(llvm::Instruction &inst) {
   auto &var{dec_ctx.value_decls[&inst]};
   if (var) {
     auto expr{expr_gen.visit(inst)};
-    return dec_ctx.ast.CreateAssign(dec_ctx.ast.CreateDeclRef(var), expr);
+    return ast.CreateAssign(ast.CreateDeclRef(var), expr);
   }
   return nullptr;
 }
@@ -1106,7 +1082,7 @@ void IRToASTVisitor::VisitArgument(llvm::Argument &arg) {
   auto fdecl{clang::cast<clang::FunctionDecl>(dec_ctx.value_decls[func])};
   auto argtype{dec_ctx.type_provider->GetArgumentType(arg)};
   // Create a declaration
-  parm = dec_ctx.ast.CreateParamDecl(fdecl, argtype, name);
+  parm = ast.CreateParamDecl(fdecl, argtype, name);
 }
 
 void IRToASTVisitor::VisitBasicBlock(llvm::BasicBlock &block,
@@ -1126,8 +1102,7 @@ void IRToASTVisitor::VisitBasicBlock(llvm::BasicBlock &block,
     auto use{*it};
     auto var{dec_ctx.value_decls[use->getUser()]};
     auto expr{expr_gen.CreateOperandExpr(*use)};
-    stmts.push_back(
-        dec_ctx.ast.CreateAssign(dec_ctx.ast.CreateDeclRef(var), expr));
+    stmts.push_back(ast.CreateAssign(ast.CreateDeclRef(var), expr));
   }
 }
 
@@ -1156,7 +1131,7 @@ void IRToASTVisitor::VisitFunctionDecl(llvm::Function &func) {
   clang::FunctionProtoType::ExtProtoInfo epi;
   epi.Variadic = func.isVarArg();
   auto ftype{dec_ctx.ast_ctx.getFunctionType(ret_type, arg_types, epi)};
-  decl = dec_ctx.ast.CreateFunctionDecl(tudecl, ftype, name);
+  decl = ast.CreateFunctionDecl(tudecl, ftype, name);
 
   tudecl->addDecl(decl);
 
@@ -1192,7 +1167,7 @@ void IRToASTVisitor::VisitFunctionDecl(llvm::Function &func) {
       // (`varname_addr` being a common name used by clang for variables used as
       // storage for parameters e.g. a parameter named "foo" has a corresponding
       // local variable named "foo_addr").
-      var = dec_ctx.ast.CreateVarDecl(
+      var = ast.CreateVarDecl(
           fdecl, dec_ctx.GetQualType(alloca->getAllocatedType()), name);
       fdecl->addDecl(var);
     } else if (inst.hasNUsesOrMore(2) ||
@@ -1216,7 +1191,7 @@ void IRToASTVisitor::VisitFunctionDecl(llvm::Function &func) {
           type = dec_ctx.ast_ctx.getPointerType(arrayType->getElementType());
         }
 
-        var = dec_ctx.ast.CreateVarDecl(fdecl, type, name);
+        var = ast.CreateVarDecl(fdecl, type, name);
         fdecl->addDecl(var);
 
         if (auto phi = llvm::dyn_cast<llvm::PHINode>(&inst)) {
@@ -1244,14 +1219,14 @@ void IRToASTVisitor::VisitFunctionDecl(llvm::Function &func) {
                   std::to_string(GetNumDecls<clang::FunctionDecl>(tudecl))};
         auto ftype{iasm->getFunctionType()};
         auto type{dec_ctx.GetQualType(ftype)};
-        decl = dec_ctx.ast.CreateFunctionDecl(tudecl, type, name);
+        decl = ast.CreateFunctionDecl(tudecl, type, name);
 
         std::vector<clang::ParmVarDecl *> iasm_params;
         for (auto arg : ftype->params()) {
           auto arg_type{dec_ctx.GetQualType(arg)};
           auto name{"arg_" + std::to_string(iasm_params.size())};
-          iasm_params.push_back(dec_ctx.ast.CreateParamDecl(
-              decl->getDeclContext(), arg_type, name));
+          iasm_params.push_back(
+              ast.CreateParamDecl(decl->getDeclContext(), arg_type, name));
         }
 
         auto fdecl{decl->getAsFunction()};

--- a/lib/AST/IRToASTVisitor.cpp
+++ b/lib/AST/IRToASTVisitor.cpp
@@ -86,8 +86,8 @@ clang::Expr *IRToASTVisitor::ConvertExpr(z3::expr expr) {
 
     for (auto sw_case : inst->cases()) {
       if (sw_case.getCaseIndex() == case_idx) {
-        return ast.CreateEQ(CreateOperandExpr(inst->getOperandUse(0)),
-                            CreateConstantExpr(sw_case.getCaseValue()));
+        return dec_ctx.ast.CreateEQ(CreateOperandExpr(inst->getOperandUse(0)),
+                                    CreateConstantExpr(sw_case.getCaseValue()));
       }
     }
 
@@ -111,31 +111,31 @@ clang::Expr *IRToASTVisitor::ConvertExpr(z3::expr expr) {
   switch (expr.decl().decl_kind()) {
     case Z3_OP_TRUE:
       CHECK_EQ(expr.num_args(), 0) << "True cannot have arguments";
-      return ast.CreateTrue();
+      return dec_ctx.ast.CreateTrue();
     case Z3_OP_FALSE:
       CHECK_EQ(expr.num_args(), 0) << "False cannot have arguments";
-      return ast.CreateFalse();
+      return dec_ctx.ast.CreateFalse();
     case Z3_OP_AND: {
       // Since AND and OR expressions are n-ary we need to convert them to
       // binary. If they have only one subexpression, we can forego the AND/OR
       // altogether.
       clang::Expr *res{ConvertExpr(expr.arg(0))};
       for (auto i{1U}; i < expr.num_args(); ++i) {
-        res = ast.CreateLAnd(res, ConvertExpr(expr.arg(i)));
+        res = dec_ctx.ast.CreateLAnd(res, ConvertExpr(expr.arg(i)));
       }
       return res;
     }
     case Z3_OP_OR: {
       clang::Expr *res{ConvertExpr(expr.arg(0))};
       for (auto i{1U}; i < expr.num_args(); ++i) {
-        res = ast.CreateLOr(res, ConvertExpr(expr.arg(i)));
+        res = dec_ctx.ast.CreateLOr(res, ConvertExpr(expr.arg(i)));
       }
       return res;
     }
     case Z3_OP_NOT: {
       CHECK_EQ(expr.num_args(), 1) << "Not must have one argument";
       auto sub{ConvertExpr(expr.arg(0))};
-      auto neg{ast.CreateLNot(sub)};
+      auto neg{dec_ctx.ast.CreateLNot(sub)};
       CopyProvenance(sub, neg, dec_ctx.use_provenance);
       return neg;
     }
@@ -160,14 +160,14 @@ void ExprGen::VisitGlobalVar(llvm::GlobalVariable &gvar) {
   }
 
   auto type{gvar.getValueType()};
-  auto tudecl{ast_ctx.getTranslationUnitDecl()};
+  auto tudecl{dec_ctx.ast_ctx.getTranslationUnitDecl()};
   auto name{gvar.getName().str()};
   if (name.empty()) {
     name = "gvar" + std::to_string(GetNumDecls<clang::VarDecl>(tudecl));
   }
 
   // Create a variable declaration
-  var = ast.CreateVarDecl(tudecl, GetQualType(type), name);
+  var = dec_ctx.ast.CreateVarDecl(tudecl, GetQualType(type), name);
   // Add to translation unit
   tudecl->addDecl(var);
 
@@ -187,33 +187,33 @@ clang::QualType ExprGen::GetQualType(llvm::Type *type) {
   clang::QualType result;
   switch (type->getTypeID()) {
     case llvm::Type::VoidTyID:
-      result = ast_ctx.VoidTy;
+      result = dec_ctx.ast_ctx.VoidTy;
       break;
 
     case llvm::Type::HalfTyID:
-      result = ast_ctx.HalfTy;
+      result = dec_ctx.ast_ctx.HalfTy;
       break;
 
     case llvm::Type::FloatTyID:
-      result = ast_ctx.FloatTy;
+      result = dec_ctx.ast_ctx.FloatTy;
       break;
 
     case llvm::Type::DoubleTyID:
-      result = ast_ctx.DoubleTy;
+      result = dec_ctx.ast_ctx.DoubleTy;
       break;
 
     case llvm::Type::X86_FP80TyID:
-      result = ast_ctx.LongDoubleTy;
+      result = dec_ctx.ast_ctx.LongDoubleTy;
       break;
 
     case llvm::Type::FP128TyID:
-      result = ast_ctx.Float128Ty;
+      result = dec_ctx.ast_ctx.Float128Ty;
       break;
 
     case llvm::Type::IntegerTyID: {
       auto size{type->getIntegerBitWidth()};
       CHECK(size > 0) << "Integer bit width has to be greater than 0";
-      result = ast.GetLeastIntTypeForBitWidth(size, /*sign=*/0);
+      result = dec_ctx.ast.GetLeastIntTypeForBitWidth(size, /*sign=*/0);
     } break;
 
     case llvm::Type::FunctionTyID: {
@@ -225,15 +225,15 @@ clang::QualType ExprGen::GetQualType(llvm::Type *type) {
       }
       auto epi{clang::FunctionProtoType::ExtProtoInfo()};
       epi.Variadic = func->isVarArg();
-      result = ast_ctx.getFunctionType(ret, params, epi);
+      result = dec_ctx.ast_ctx.getFunctionType(ret, params, epi);
     } break;
 
     case llvm::Type::PointerTyID: {
       auto ptr_type{llvm::cast<llvm::PointerType>(type)};
       if (ptr_type->isOpaque()) {
-        result = ast_ctx.VoidPtrTy;
+        result = dec_ctx.ast_ctx.VoidPtrTy;
       } else {
-        result = ast_ctx.getPointerType(
+        result = dec_ctx.ast_ctx.getPointerType(
             GetQualType(ptr_type->getNonOpaquePointerElementType()));
       }
     } break;
@@ -241,7 +241,7 @@ clang::QualType ExprGen::GetQualType(llvm::Type *type) {
     case llvm::Type::ArrayTyID: {
       auto arr{llvm::cast<llvm::ArrayType>(type)};
       auto elm{GetQualType(arr->getElementType())};
-      result = ast_ctx.getConstantArrayType(
+      result = dec_ctx.ast_ctx.getConstantArrayType(
           elm, llvm::APInt(64, arr->getNumElements()), nullptr,
           clang::ArrayType::ArraySizeModifier::Normal, 0);
     } break;
@@ -250,7 +250,7 @@ clang::QualType ExprGen::GetQualType(llvm::Type *type) {
       clang::RecordDecl *sdecl{nullptr};
       auto &decl{dec_ctx.type_decls[type]};
       if (!decl) {
-        auto tudecl{ast_ctx.getTranslationUnitDecl()};
+        auto tudecl{dec_ctx.ast_ctx.getTranslationUnitDecl()};
         auto strct{llvm::cast<llvm::StructType>(type)};
         auto sname{strct->isLiteral()
                        ? ("literal_struct_" +
@@ -261,13 +261,13 @@ clang::QualType ExprGen::GetQualType(llvm::Type *type) {
         }
 
         // Create a C struct declaration
-        decl = sdecl = ast.CreateStructDecl(tudecl, sname);
+        decl = sdecl = dec_ctx.ast.CreateStructDecl(tudecl, sname);
 
         // Add fields to the C struct
         for (auto ecnt{0U}; ecnt < strct->getNumElements(); ++ecnt) {
           auto etype{GetQualType(strct->getElementType(ecnt))};
           auto fname{"field" + std::to_string(ecnt)};
-          sdecl->addDecl(ast.CreateFieldDecl(sdecl, etype, fname));
+          sdecl->addDecl(dec_ctx.ast.CreateFieldDecl(sdecl, etype, fname));
         }
 
         // Complete the C struct definition
@@ -278,11 +278,11 @@ clang::QualType ExprGen::GetQualType(llvm::Type *type) {
       } else {
         sdecl = clang::cast<clang::RecordDecl>(decl);
       }
-      result = ast_ctx.getRecordType(sdecl);
+      result = dec_ctx.ast_ctx.getRecordType(sdecl);
     } break;
 
     case llvm::Type::MetadataTyID:
-      result = ast_ctx.VoidPtrTy;
+      result = dec_ctx.ast_ctx.VoidPtrTy;
       break;
 
     default: {
@@ -291,7 +291,7 @@ clang::QualType ExprGen::GetQualType(llvm::Type *type) {
         auto etype{GetQualType(vtype->getElementType())};
         auto ecnt{vtype->getNumElements()};
         auto vkind{clang::VectorType::GenericVector};
-        result = ast_ctx.getVectorType(etype, ecnt, vkind);
+        result = dec_ctx.ast_ctx.getVectorType(etype, ecnt, vkind);
       } else {
         THROW() << "Unknown LLVM Type: " << LLVMThingToString(type);
       }
@@ -318,8 +318,8 @@ clang::Expr *ExprGen::CreateConstantExpr(llvm::Constant *constant) {
     return CreateConstantExpr(alias->getAliasee());
   } else if (auto global = llvm::dyn_cast<llvm::GlobalValue>(constant)) {
     auto decl{dec_ctx.value_decls[global]};
-    auto ref{ast.CreateDeclRef(decl)};
-    return ast.CreateAddrOf(ref);
+    auto ref{dec_ctx.ast.CreateDeclRef(decl)};
+    return dec_ctx.ast.CreateAddrOf(ref);
   }
   return CreateLiteralExpr(constant);
 }
@@ -339,7 +339,7 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
         init_exprs.push_back(CreateConstantExpr(elm));
       }
     }
-    return ast.CreateInitList(init_exprs);
+    return dec_ctx.ast.CreateInitList(init_exprs);
   }};
 
   switch (l_type->getTypeID()) {
@@ -348,7 +348,7 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
     case llvm::Type::FloatTyID:
     case llvm::Type::DoubleTyID:
     case llvm::Type::X86_FP80TyID: {
-      result = ast.CreateFPLit(
+      result = dec_ctx.ast.CreateFPLit(
           llvm::cast<llvm::ConstantFP>(constant)->getValueAPF());
     } break;
     // Integers
@@ -356,24 +356,27 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
       if (llvm::isa<llvm::ConstantInt>(constant)) {
         auto val{llvm::cast<llvm::ConstantInt>(constant)->getValue()};
         auto val_bitwidth{val.getBitWidth()};
-        auto ull_bitwidth{ast_ctx.getIntWidth(ast_ctx.LongLongTy)};
+        auto ull_bitwidth{
+            dec_ctx.ast_ctx.getIntWidth(dec_ctx.ast_ctx.LongLongTy)};
         if (val_bitwidth == 1U) {
           // Booleans
-          result = ast.CreateIntLit(val);
+          result = dec_ctx.ast.CreateIntLit(val);
         } else if (val.getActiveBits() <= ull_bitwidth) {
-          result = ast.CreateAdjustedIntLit(val);
+          result = dec_ctx.ast.CreateAdjustedIntLit(val);
         } else {
           // Values wider than `long long` will be represented as:
           // (uint128_t)hi_64 << 64U | lo_64
-          auto lo{ast.CreateIntLit(val.extractBits(64U, 0U))};
-          auto hi{ast.CreateIntLit(val.extractBits(val_bitwidth - 64U, 64U))};
-          auto shl_val{ast.CreateIntLit(llvm::APInt(32U, 64U))};
-          result = ast.CreateCStyleCast(ast_ctx.UnsignedInt128Ty, hi);
-          result = ast.CreateShl(result, shl_val);
-          result = ast.CreateOr(result, lo);
+          auto lo{dec_ctx.ast.CreateIntLit(val.extractBits(64U, 0U))};
+          auto hi{dec_ctx.ast.CreateIntLit(
+              val.extractBits(val_bitwidth - 64U, 64U))};
+          auto shl_val{dec_ctx.ast.CreateIntLit(llvm::APInt(32U, 64U))};
+          result = dec_ctx.ast.CreateCStyleCast(
+              dec_ctx.ast_ctx.UnsignedInt128Ty, hi);
+          result = dec_ctx.ast.CreateShl(result, shl_val);
+          result = dec_ctx.ast.CreateOr(result, lo);
         }
       } else if (llvm::isa<llvm::UndefValue>(constant)) {
-        result = ast.CreateUndefInteger(c_type);
+        result = dec_ctx.ast.CreateUndefInteger(c_type);
       } else {
         THROW() << "Unsupported integer constant";
       }
@@ -381,9 +384,9 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
     // Pointers
     case llvm::Type::PointerTyID: {
       if (llvm::isa<llvm::ConstantPointerNull>(constant)) {
-        result = ast.CreateNull();
+        result = dec_ctx.ast.CreateNull();
       } else if (llvm::isa<llvm::UndefValue>(constant)) {
-        result = ast.CreateUndefPointer(c_type);
+        result = dec_ctx.ast.CreateUndefPointer(c_type);
       } else {
         THROW() << "Unsupported pointer constant";
       }
@@ -396,7 +399,7 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
         if (auto arr = llvm::dyn_cast<llvm::ConstantDataArray>(constant)) {
           init = arr->getAsString().str();
         }
-        result = ast.CreateStrLit(init);
+        result = dec_ctx.ast.CreateStrLit(init);
       } else {
         result = CreateInitListLiteral();
       }
@@ -409,7 +412,7 @@ clang::Expr *ExprGen::CreateLiteralExpr(llvm::Constant *constant) {
     default: {
       // Vectors
       if (l_type->isVectorTy()) {
-        result = ast.CreateCompoundLit(c_type, CreateInitListLiteral());
+        result = dec_ctx.ast.CreateCompoundLit(c_type, CreateInitListLiteral());
       } else {
         THROW() << "Unknown LLVM constant type: " << LLVMThingToString(l_type);
       }
@@ -428,7 +431,7 @@ clang::Expr *ExprGen::CreateOperandExpr(llvm::Use &val) {
   DLOG(INFO) << "Getting Expr for " << LLVMThingToString(val);
   auto CreateRef{[this, &val] {
     auto decl{dec_ctx.value_decls[val]};
-    auto ref{ast.CreateDeclRef(decl)};
+    auto ref{dec_ctx.ast.CreateDeclRef(decl)};
     dec_ctx.use_provenance[ref] = &val;
     return ref;
   }};
@@ -440,7 +443,7 @@ clang::Expr *ExprGen::CreateOperandExpr(llvm::Use &val) {
   } else if (llvm::isa<llvm::AllocaInst>(val)) {
     // Operand is an l-value (variable, function, ...)
     // Add a `&` operator
-    res = ast.CreateAddrOf(CreateRef());
+    res = dec_ctx.ast.CreateAddrOf(CreateRef());
   } else if (llvm::isa<llvm::Argument>(val)) {
     // Operand is a function argument or local variable
     auto arg{llvm::cast<llvm::Argument>(val)};
@@ -453,24 +456,24 @@ clang::Expr *ExprGen::CreateOperandExpr(llvm::Use &val) {
       // arguments assume they are dealing with pointers.
       auto &temp{dec_ctx.temp_decls[arg]};
       if (!temp) {
-        auto addr_of_arg{ast.CreateAddrOf(ref)};
+        auto addr_of_arg{dec_ctx.ast.CreateAddrOf(ref)};
         auto func{arg->getParent()};
         auto fdecl{dec_ctx.value_decls[func]->getAsFunction()};
         auto argdecl{clang::cast<clang::ParmVarDecl>(dec_ctx.value_decls[arg])};
-        temp = ast.CreateVarDecl(fdecl, GetQualType(arg->getType()),
-                                 argdecl->getName().str() + "_ptr");
+        temp = dec_ctx.ast.CreateVarDecl(fdecl, GetQualType(arg->getType()),
+                                         argdecl->getName().str() + "_ptr");
         temp->setInit(addr_of_arg);
         fdecl->addDecl(temp);
       }
 
-      res = ast.CreateDeclRef(temp);
+      res = dec_ctx.ast.CreateDeclRef(temp);
     } else {
       res = ref;
     }
   } else if (auto inst = llvm::dyn_cast<llvm::Instruction>(val)) {
     // Operand is a result of an expression
     if (auto decl = dec_ctx.value_decls[inst]) {
-      res = ast.CreateDeclRef(decl);
+      res = dec_ctx.ast.CreateDeclRef(decl);
     } else {
       res = visit(inst);
     }
@@ -503,7 +506,8 @@ clang::Expr *ExprGen::visitMemCpyInst(llvm::MemCpyInst &inst) {
     args.push_back(CreateOperandExpr(arg));
   }
 
-  return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy, args);
+  return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy,
+                                       args);
 }
 
 clang::Expr *ExprGen::visitMemCpyInlineInst(llvm::MemCpyInlineInst &inst) {
@@ -515,7 +519,8 @@ clang::Expr *ExprGen::visitMemCpyInlineInst(llvm::MemCpyInlineInst &inst) {
     args.push_back(CreateOperandExpr(arg));
   }
 
-  return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy, args);
+  return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy,
+                                       args);
 }
 
 clang::Expr *ExprGen::visitAnyMemMoveInst(llvm::AnyMemMoveInst &inst) {
@@ -527,7 +532,8 @@ clang::Expr *ExprGen::visitAnyMemMoveInst(llvm::AnyMemMoveInst &inst) {
     args.push_back(CreateOperandExpr(arg));
   }
 
-  return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memmove, args);
+  return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memmove,
+                                       args);
 }
 
 clang::Expr *ExprGen::visitAnyMemSetInst(llvm::AnyMemSetInst &inst) {
@@ -539,7 +545,8 @@ clang::Expr *ExprGen::visitAnyMemSetInst(llvm::AnyMemSetInst &inst) {
     args.push_back(CreateOperandExpr(arg));
   }
 
-  return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memset, args);
+  return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memset,
+                                       args);
 }
 
 clang::Expr *ExprGen::visitIntrinsicInst(llvm::IntrinsicInst &inst) {
@@ -576,9 +583,10 @@ clang::Expr *ExprGen::visitCallInst(llvm::CallInst &inst) {
     auto &arg{inst.getArgOperandUse(i)};
     auto opnd{CreateOperandExpr(arg)};
     if (inst.getParamAttr(i, llvm::Attribute::ByVal).isValid()) {
-      auto ptr_type{
-          ast_ctx.getPointerType(GetQualType(inst.getParamByValType(i)))};
-      opnd = ast.CreateDeref(ast.CreateCStyleCast(ptr_type, opnd));
+      auto ptr_type{dec_ctx.ast_ctx.getPointerType(
+          GetQualType(inst.getParamByValType(i)))};
+      opnd =
+          dec_ctx.ast.CreateDeref(dec_ctx.ast.CreateCStyleCast(ptr_type, opnd));
       dec_ctx.use_provenance[opnd] = &arg;
     }
     args.push_back(opnd);
@@ -589,21 +597,23 @@ clang::Expr *ExprGen::visitCallInst(llvm::CallInst &inst) {
   if (auto func = llvm::dyn_cast<llvm::Function>(callee)) {
     auto fdecl{dec_ctx.value_decls[func]->getAsFunction()};
     if (func->getFunctionType() == inst.getFunctionType()) {
-      callexpr = ast.CreateCall(fdecl, args);
+      callexpr = dec_ctx.ast.CreateCall(fdecl, args);
     } else {
       // Cast function type to match the one used in the call instruction
-      auto funcPtr{ast_ctx.getPointerType(GetQualType(inst.getFunctionType()))};
-      auto callee{ast.CreateAddrOf(ast.CreateDeclRef(fdecl))};
-      auto cast{ast.CreateCStyleCast(funcPtr, callee)};
-      callexpr = ast.CreateCall(cast, args);
+      auto funcPtr{
+          dec_ctx.ast_ctx.getPointerType(GetQualType(inst.getFunctionType()))};
+      auto callee{dec_ctx.ast.CreateAddrOf(dec_ctx.ast.CreateDeclRef(fdecl))};
+      auto cast{dec_ctx.ast.CreateCStyleCast(funcPtr, callee)};
+      callexpr = dec_ctx.ast.CreateCall(cast, args);
     }
   } else if (auto iasm = llvm::dyn_cast<llvm::InlineAsm>(callee)) {
     auto fdecl{dec_ctx.value_decls[iasm]->getAsFunction()};
-    callexpr = ast.CreateCall(fdecl, args);
+    callexpr = dec_ctx.ast.CreateCall(fdecl, args);
   } else if (llvm::isa<llvm::PointerType>(callee->getType())) {
-    auto funcPtr{ast_ctx.getPointerType(GetQualType(inst.getFunctionType()))};
-    auto cast{ast.CreateCStyleCast(funcPtr, CreateOperandExpr(callee))};
-    callexpr = ast.CreateCall(cast, args);
+    auto funcPtr{
+        dec_ctx.ast_ctx.getPointerType(GetQualType(inst.getFunctionType()))};
+    auto cast{dec_ctx.ast.CreateCStyleCast(funcPtr, CreateOperandExpr(callee))};
+    callexpr = dec_ctx.ast.CreateCall(cast, args);
   } else {
     LOG(FATAL) << "Callee is not a function";
   }
@@ -671,14 +681,14 @@ clang::Expr *ExprGen::visitGetElementPtrInst(llvm::GetElementPtrInst &inst) {
   if (is_string_access()) {
     auto gvar{llvm::cast<llvm::GlobalVariable>(ptr_opnd)};
     auto arr{llvm::cast<llvm::ConstantDataArray>(gvar->getInitializer())};
-    return ast.CreateStrLit(arr->getAsString().str().c_str());
+    return dec_ctx.ast.CreateStrLit(arr->getAsString().str().c_str());
   }
 
   auto base{CreateOperandExpr(ptr_opnd)};
 
   auto ptr_type{
-      ast_ctx.getPointerType(GetQualType(inst.getSourceElementType()))};
-  base = ast.CreateCStyleCast(ptr_type, base);
+      dec_ctx.ast_ctx.getPointerType(GetQualType(inst.getSourceElementType()))};
+  base = dec_ctx.ast.CreateCStyleCast(ptr_type, base);
 
   for (auto &idx : llvm::make_range(inst.idx_begin(), inst.idx_end())) {
     GetQualType(indexed_type);
@@ -687,14 +697,14 @@ clang::Expr *ExprGen::visitGetElementPtrInst(llvm::GetElementPtrInst &inst) {
       case llvm::Type::PointerTyID: {
         CHECK(idx == *inst.idx_begin())
             << "Indexing an llvm::PointerType is only valid at first index";
-        base = ast.CreateArraySub(base, CreateOperandExpr(idx));
+        base = dec_ctx.ast.CreateArraySub(base, CreateOperandExpr(idx));
         std::vector<uint64_t> indices({0});
         indexed_type = llvm::GetElementPtrInst::getIndexedType(
             inst.getSourceElementType(), indices);
       } break;
       // Arrays
       case llvm::Type::ArrayTyID: {
-        base = ast.CreateArraySub(base, CreateOperandExpr(idx));
+        base = dec_ctx.ast.CreateArraySub(base, CreateOperandExpr(idx));
         indexed_type =
             llvm::cast<llvm::ArrayType>(indexed_type)->getElementType();
       } break;
@@ -708,7 +718,7 @@ clang::Expr *ExprGen::visitGetElementPtrInst(llvm::GetElementPtrInst &inst) {
         auto field_it{record->field_begin()};
         std::advance(field_it, mem_idx->getLimitedValue());
         CHECK(field_it != record->field_end()) << "GEP index is out of bounds";
-        base = ast.CreateDot(base, *field_it);
+        base = dec_ctx.ast.CreateDot(base, *field_it);
         indexed_type =
             llvm::cast<llvm::StructType>(indexed_type)->getTypeAtIndex(idx);
       } break;
@@ -719,9 +729,10 @@ clang::Expr *ExprGen::visitGetElementPtrInst(llvm::GetElementPtrInst &inst) {
           auto l_vec_ty{llvm::cast<llvm::VectorType>(indexed_type)};
           auto l_elm_ty{l_vec_ty->getElementType()};
           auto c_elm_ty{GetQualType(l_elm_ty)};
-          base = ast.CreateCStyleCast(ast_ctx.getPointerType(c_elm_ty),
-                                      ast.CreateAddrOf(base));
-          base = ast.CreateArraySub(base, CreateOperandExpr(idx));
+          base = dec_ctx.ast.CreateCStyleCast(
+              dec_ctx.ast_ctx.getPointerType(c_elm_ty),
+              dec_ctx.ast.CreateAddrOf(base));
+          base = dec_ctx.ast.CreateArraySub(base, CreateOperandExpr(idx));
           indexed_type = l_elm_ty;
         } else {
           THROW() << "Indexing an unknown type: "
@@ -731,7 +742,7 @@ clang::Expr *ExprGen::visitGetElementPtrInst(llvm::GetElementPtrInst &inst) {
     }
   }
 
-  return ast.CreateAddrOf(base);
+  return dec_ctx.ast.CreateAddrOf(base);
 }
 
 clang::Expr *ExprGen::visitInstruction(llvm::Instruction &inst) {
@@ -745,7 +756,7 @@ clang::Expr *ExprGen::visitExtractValueInst(llvm::ExtractValueInst &inst) {
   auto base{CreateOperandExpr(inst.getOperandUse(0))};
   auto indexed_type{inst.getAggregateOperand()->getType()};
   if (clang::isa<clang::InitListExpr>(base)) {
-    base = ast.CreateCompoundLit(GetQualType(indexed_type), base);
+    base = dec_ctx.ast.CreateCompoundLit(GetQualType(indexed_type), base);
   }
 
   for (auto idx : llvm::make_range(inst.idx_begin(), inst.idx_end())) {
@@ -753,8 +764,9 @@ clang::Expr *ExprGen::visitExtractValueInst(llvm::ExtractValueInst &inst) {
     switch (indexed_type->getTypeID()) {
       // Arrays
       case llvm::Type::ArrayTyID: {
-        base = ast.CreateArraySub(
-            base, ast.CreateIntLit(llvm::APInt(sizeof(unsigned) * 8U, idx)));
+        base = dec_ctx.ast.CreateArraySub(
+            base,
+            dec_ctx.ast.CreateIntLit(llvm::APInt(sizeof(unsigned) * 8U, idx)));
         indexed_type =
             llvm::cast<llvm::ArrayType>(indexed_type)->getElementType();
       } break;
@@ -767,7 +779,7 @@ clang::Expr *ExprGen::visitExtractValueInst(llvm::ExtractValueInst &inst) {
         std::advance(field_it, idx);
         CHECK(field_it != record->field_end())
             << "ExtractValue index is out of bounds";
-        base = ast.CreateDot(base, *field_it);
+        base = dec_ctx.ast.CreateDot(base, *field_it);
         indexed_type =
             llvm::cast<llvm::StructType>(indexed_type)->getTypeAtIndex(idx);
       } break;
@@ -783,10 +795,10 @@ clang::Expr *ExprGen::visitExtractValueInst(llvm::ExtractValueInst &inst) {
 
 clang::Expr *ExprGen::visitLoadInst(llvm::LoadInst &inst) {
   DLOG(INFO) << "visitLoadInst: " << LLVMThingToString(&inst);
-  auto ptr_type{ast_ctx.getPointerType(GetQualType(inst.getType()))};
-  auto cast{
-      ast.CreateCStyleCast(ptr_type, CreateOperandExpr(inst.getOperandUse(0)))};
-  return ast.CreateDeref(cast);
+  auto ptr_type{dec_ctx.ast_ctx.getPointerType(GetQualType(inst.getType()))};
+  auto cast{dec_ctx.ast.CreateCStyleCast(
+      ptr_type, CreateOperandExpr(inst.getOperandUse(0)))};
+  return dec_ctx.ast.CreateDeref(cast);
 }
 
 clang::Expr *ExprGen::visitBinaryOperator(llvm::BinaryOperator &inst) {
@@ -796,72 +808,76 @@ clang::Expr *ExprGen::visitBinaryOperator(llvm::BinaryOperator &inst) {
   auto rhs{CreateOperandExpr(inst.getOperandUse(1))};
   // Sign-cast int operand
   auto IntSignCast{[this](clang::Expr *operand, bool sign) {
-    auto type{ast_ctx.getIntTypeForBitwidth(
-        ast_ctx.getTypeSize(operand->getType()), sign)};
-    return ast.CreateCStyleCast(type, operand);
+    auto type{dec_ctx.ast_ctx.getIntTypeForBitwidth(
+        dec_ctx.ast_ctx.getTypeSize(operand->getType()), sign)};
+    return dec_ctx.ast.CreateCStyleCast(type, operand);
   }};
   clang::Expr *res;
   // Where the magic happens
   switch (inst.getOpcode()) {
     case llvm::BinaryOperator::LShr:
-      res = ast.CreateShr(IntSignCast(lhs, false), rhs);
+      res = dec_ctx.ast.CreateShr(IntSignCast(lhs, false), rhs);
       break;
 
     case llvm::BinaryOperator::AShr:
-      res = ast.CreateShr(IntSignCast(lhs, true), rhs);
+      res = dec_ctx.ast.CreateShr(IntSignCast(lhs, true), rhs);
       break;
 
     case llvm::BinaryOperator::Shl:
-      res = ast.CreateShl(lhs, rhs);
+      res = dec_ctx.ast.CreateShl(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::And:
-      res = inst.getType()->isIntegerTy(1U) ? ast.CreateLAnd(lhs, rhs)
-                                            : ast.CreateAnd(lhs, rhs);
+      res = inst.getType()->isIntegerTy(1U) ? dec_ctx.ast.CreateLAnd(lhs, rhs)
+                                            : dec_ctx.ast.CreateAnd(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::Or:
-      res = inst.getType()->isIntegerTy(1U) ? ast.CreateLOr(lhs, rhs)
-                                            : ast.CreateOr(lhs, rhs);
+      res = inst.getType()->isIntegerTy(1U) ? dec_ctx.ast.CreateLOr(lhs, rhs)
+                                            : dec_ctx.ast.CreateOr(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::Xor:
-      res = ast.CreateXor(lhs, rhs);
+      res = dec_ctx.ast.CreateXor(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::URem:
-      res = ast.CreateRem(IntSignCast(lhs, false), IntSignCast(rhs, false));
+      res = dec_ctx.ast.CreateRem(IntSignCast(lhs, false),
+                                  IntSignCast(rhs, false));
       break;
 
     case llvm::BinaryOperator::SRem:
-      res = ast.CreateRem(IntSignCast(lhs, true), IntSignCast(rhs, true));
+      res =
+          dec_ctx.ast.CreateRem(IntSignCast(lhs, true), IntSignCast(rhs, true));
       break;
 
     case llvm::BinaryOperator::UDiv:
-      res = ast.CreateDiv(IntSignCast(lhs, false), IntSignCast(rhs, false));
+      res = dec_ctx.ast.CreateDiv(IntSignCast(lhs, false),
+                                  IntSignCast(rhs, false));
       break;
 
     case llvm::BinaryOperator::SDiv:
-      res = ast.CreateDiv(IntSignCast(lhs, true), IntSignCast(rhs, true));
+      res =
+          dec_ctx.ast.CreateDiv(IntSignCast(lhs, true), IntSignCast(rhs, true));
       break;
 
     case llvm::BinaryOperator::FDiv:
-      res = ast.CreateDiv(lhs, rhs);
+      res = dec_ctx.ast.CreateDiv(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::Add:
     case llvm::BinaryOperator::FAdd:
-      res = ast.CreateAdd(lhs, rhs);
+      res = dec_ctx.ast.CreateAdd(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::Sub:
     case llvm::BinaryOperator::FSub:
-      res = ast.CreateSub(lhs, rhs);
+      res = dec_ctx.ast.CreateSub(lhs, rhs);
       break;
 
     case llvm::BinaryOperator::Mul:
     case llvm::BinaryOperator::FMul:
-      res = ast.CreateMul(lhs, rhs);
+      res = dec_ctx.ast.CreateMul(lhs, rhs);
       break;
 
     default:
@@ -879,11 +895,12 @@ clang::Expr *ExprGen::visitCmpInst(llvm::CmpInst &inst) {
   // Sign-cast int operand
   auto IntSignCast{[this](clang::Expr *op, bool sign) {
     auto ot{op->getType()};
-    auto rt{ast_ctx.getIntTypeForBitwidth(ast_ctx.getTypeSize(ot), sign)};
+    auto rt{dec_ctx.ast_ctx.getIntTypeForBitwidth(
+        dec_ctx.ast_ctx.getTypeSize(ot), sign)};
     if (rt == ot) {
       return op;
     } else {
-      auto cast{ast.CreateCStyleCast(rt, op)};
+      auto cast{dec_ctx.ast.CreateCStyleCast(rt, op)};
       CopyProvenance(op, cast, dec_ctx.use_provenance);
       return (clang::Expr *)cast;
     }
@@ -905,70 +922,72 @@ clang::Expr *ExprGen::visitCmpInst(llvm::CmpInst &inst) {
     case llvm::CmpInst::ICMP_UGT:
     case llvm::CmpInst::ICMP_SGT:
     case llvm::CmpInst::FCMP_OGT:
-      res = ast.CreateGT(lhs, rhs);
+      res = dec_ctx.ast.CreateGT(lhs, rhs);
       break;
 
     case llvm::CmpInst::ICMP_ULT:
     case llvm::CmpInst::ICMP_SLT:
     case llvm::CmpInst::FCMP_OLT:
-      res = ast.CreateLT(lhs, rhs);
+      res = dec_ctx.ast.CreateLT(lhs, rhs);
       break;
 
     case llvm::CmpInst::ICMP_UGE:
     case llvm::CmpInst::ICMP_SGE:
     case llvm::CmpInst::FCMP_OGE:
-      res = ast.CreateGE(lhs, rhs);
+      res = dec_ctx.ast.CreateGE(lhs, rhs);
       break;
 
     case llvm::CmpInst::ICMP_ULE:
     case llvm::CmpInst::ICMP_SLE:
     case llvm::CmpInst::FCMP_OLE:
-      res = ast.CreateLE(lhs, rhs);
+      res = dec_ctx.ast.CreateLE(lhs, rhs);
       break;
 
     case llvm::CmpInst::ICMP_EQ:
     case llvm::CmpInst::FCMP_OEQ:
-      res = ast.CreateEQ(lhs, rhs);
+      res = dec_ctx.ast.CreateEQ(lhs, rhs);
       break;
 
     case llvm::CmpInst::ICMP_NE:
-      res = ast.CreateNE(lhs, rhs);
+      res = dec_ctx.ast.CreateNE(lhs, rhs);
       break;
 
     case llvm::CmpInst::FCMP_UGT:
-      res = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isgreater, args);
+      res = dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isgreater,
+                                          args);
       break;
 
     case llvm::CmpInst::FCMP_ULT:
-      res = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isless, args);
+      res = dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isless,
+                                          args);
       break;
 
     case llvm::CmpInst::FCMP_UGE:
-      res = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isgreaterequal,
-                                  args);
+      res = dec_ctx.ast.CreateBuiltinCall(
+          clang::Builtin::BI__builtin_isgreaterequal, args);
       break;
 
     case llvm::CmpInst::FCMP_ULE:
-      res =
-          ast.CreateBuiltinCall(clang::Builtin::BI__builtin_islessequal, args);
+      res = dec_ctx.ast.CreateBuiltinCall(
+          clang::Builtin::BI__builtin_islessequal, args);
       break;
 
     case llvm::CmpInst::FCMP_UNE:
-      res = ast.CreateBuiltinCall(clang::Builtin::BI__builtin_islessgreater,
-                                  args);
+      res = dec_ctx.ast.CreateBuiltinCall(
+          clang::Builtin::BI__builtin_islessgreater, args);
       break;
 
     case llvm::CmpInst::FCMP_UNO:
-      res =
-          ast.CreateBuiltinCall(clang::Builtin::BI__builtin_isunordered, args);
+      res = dec_ctx.ast.CreateBuiltinCall(
+          clang::Builtin::BI__builtin_isunordered, args);
       break;
 
     case llvm::CmpInst::FCMP_TRUE:
-      res = ast.CreateTrue();
+      res = dec_ctx.ast.CreateTrue();
       break;
 
     case llvm::CmpInst::FCMP_FALSE:
-      res = ast.CreateFalse();
+      res = dec_ctx.ast.CreateFalse();
       break;
 
     default:
@@ -988,19 +1007,19 @@ clang::Expr *ExprGen::visitCastInst(llvm::CastInst &inst) {
   // Adjust type
   switch (inst.getOpcode()) {
     case llvm::CastInst::Trunc: {
-      auto bitwidth{ast_ctx.getTypeSize(type)};
+      auto bitwidth{dec_ctx.ast_ctx.getTypeSize(type)};
       auto sign{operand->getType()->isSignedIntegerType()};
-      type = ast_ctx.getIntTypeForBitwidth(bitwidth, sign);
+      type = dec_ctx.ast_ctx.getIntTypeForBitwidth(bitwidth, sign);
     } break;
 
     case llvm::CastInst::ZExt: {
-      auto bitwidth{ast_ctx.getTypeSize(type)};
-      type = ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/0U);
+      auto bitwidth{dec_ctx.ast_ctx.getTypeSize(type)};
+      type = dec_ctx.ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/0U);
     } break;
 
     case llvm::CastInst::SExt: {
-      auto bitwidth{ast_ctx.getTypeSize(type)};
-      type = ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/1U);
+      auto bitwidth{dec_ctx.ast_ctx.getTypeSize(type)};
+      type = dec_ctx.ast_ctx.getIntTypeForBitwidth(bitwidth, /*signed=*/1U);
     } break;
 
     case llvm::CastInst::AddrSpaceCast:
@@ -1028,7 +1047,7 @@ clang::Expr *ExprGen::visitCastInst(llvm::CastInst &inst) {
     } break;
   }
   // Create cast
-  return ast.CreateCStyleCast(type, operand);
+  return dec_ctx.ast.CreateCStyleCast(type, operand);
 }
 
 clang::Expr *ExprGen::visitSelectInst(llvm::SelectInst &inst) {
@@ -1038,7 +1057,7 @@ clang::Expr *ExprGen::visitSelectInst(llvm::SelectInst &inst) {
   auto tval{CreateOperandExpr(inst.getOperandUse(1))};
   auto fval{CreateOperandExpr(inst.getOperandUse(2))};
 
-  return ast.CreateConditional(cond, tval, fval);
+  return dec_ctx.ast.CreateConditional(cond, tval, fval);
 }
 
 clang::Expr *ExprGen::visitFreezeInst(llvm::FreezeInst &inst) {
@@ -1054,7 +1073,7 @@ clang::Expr *ExprGen::visitUnaryOperator(llvm::UnaryOperator &inst) {
       << "Unsupported UnaryOperator: " << LLVMThingToString(&inst);
 
   auto opnd{CreateOperandExpr(inst.getOperandUse(0))};
-  return ast.CreateUnaryOp(clang::UO_Minus, opnd);
+  return dec_ctx.ast.CreateUnaryOp(clang::UO_Minus, opnd);
 }
 
 // StmtGen is tasked with populating blocks with their top-level
@@ -1098,9 +1117,9 @@ clang::Stmt *StmtGen::visitStoreInst(llvm::StoreInst &inst) {
   auto &value_opnd{inst.getOperandUse(0)};
   // Stores in LLVM IR correspond to value assignments in C
   // Get the operand we're assigning to
-  auto ptr_type{
-      ast_ctx.getPointerType(expr_gen.GetQualType(value_opnd->getType()))};
-  auto lhs{ast.CreateCStyleCast(
+  auto ptr_type{dec_ctx.ast_ctx.getPointerType(
+      expr_gen.GetQualType(value_opnd->getType()))};
+  auto lhs{dec_ctx.ast.CreateCStyleCast(
       ptr_type, expr_gen.CreateOperandExpr(
                     inst.getOperandUse(inst.getPointerOperandIndex())))};
   if (auto undef = llvm::dyn_cast<llvm::UndefValue>(value_opnd)) {
@@ -1113,20 +1132,23 @@ clang::Stmt *StmtGen::visitStoreInst(llvm::StoreInst &inst) {
     // instead
     auto DL{inst.getModule()->getDataLayout()};
     llvm::APInt sz(64, DL.getTypeAllocSize(value_opnd->getType()));
-    auto sz_expr{ast.CreateIntLit(sz)};
+    auto sz_expr{dec_ctx.ast.CreateIntLit(sz)};
     if (llvm::isa<llvm::ConstantAggregateZero>(value_opnd)) {
       llvm::APInt zero(8, 0, false);
-      std::vector<clang::Expr *> args{lhs, ast.CreateIntLit(zero), sz_expr};
-      return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memset, args);
+      std::vector<clang::Expr *> args{lhs, dec_ctx.ast.CreateIntLit(zero),
+                                      sz_expr};
+      return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memset,
+                                           args);
     } else {
       std::vector<clang::Expr *> args{lhs, rhs, sz_expr};
-      return ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy, args);
+      return dec_ctx.ast.CreateBuiltinCall(clang::Builtin::BI__builtin_memcpy,
+                                           args);
     }
   } else {
     // Create the assignemnt itself
-    auto deref{ast.CreateDeref(lhs)};
+    auto deref{dec_ctx.ast.CreateDeref(lhs)};
     CopyProvenance(lhs, deref, dec_ctx.use_provenance);
-    return ast.CreateAssign(deref, rhs);
+    return dec_ctx.ast.CreateAssign(deref, rhs);
   }
 }
 
@@ -1134,7 +1156,7 @@ clang::Stmt *StmtGen::visitCallInst(llvm::CallInst &inst) {
   auto &var{dec_ctx.value_decls[&inst]};
   auto expr{expr_gen.visit(inst)};
   if (var) {
-    return ast.CreateAssign(ast.CreateDeclRef(var), expr);
+    return dec_ctx.ast.CreateAssign(dec_ctx.ast.CreateDeclRef(var), expr);
   }
   return expr;
 }
@@ -1142,9 +1164,10 @@ clang::Stmt *StmtGen::visitCallInst(llvm::CallInst &inst) {
 clang::Stmt *StmtGen::visitReturnInst(llvm::ReturnInst &inst) {
   DLOG(INFO) << "visitReturnInst: " << LLVMThingToString(&inst);
   if (auto retval = inst.getReturnValue()) {
-    return ast.CreateReturn(expr_gen.CreateOperandExpr(inst.getOperandUse(0)));
+    return dec_ctx.ast.CreateReturn(
+        expr_gen.CreateOperandExpr(inst.getOperandUse(0)));
   } else {
-    return ast.CreateReturn();
+    return dec_ctx.ast.CreateReturn();
   }
 }
 
@@ -1175,7 +1198,7 @@ clang::Stmt *StmtGen::visitInstruction(llvm::Instruction &inst) {
   auto &var{dec_ctx.value_decls[&inst]};
   if (var) {
     auto expr{expr_gen.visit(inst)};
-    return ast.CreateAssign(ast.CreateDeclRef(var), expr);
+    return dec_ctx.ast.CreateAssign(dec_ctx.ast.CreateDeclRef(var), expr);
   }
   return nullptr;
 }
@@ -1207,7 +1230,8 @@ void IRToASTVisitor::VisitArgument(llvm::Argument &arg) {
   }
   ExprGen expr_gen{dec_ctx};
   // Create a declaration
-  parm = ast.CreateParamDecl(fdecl, expr_gen.GetQualType(argtype), name);
+  parm =
+      dec_ctx.ast.CreateParamDecl(fdecl, expr_gen.GetQualType(argtype), name);
 }
 
 // This function fixes function types for those functions that have arguments
@@ -1253,7 +1277,8 @@ void IRToASTVisitor::VisitBasicBlock(llvm::BasicBlock &block,
     auto use{*it};
     auto var{dec_ctx.value_decls[use->getUser()]};
     auto expr{expr_gen.CreateOperandExpr(*use)};
-    stmts.push_back(ast.CreateAssign(ast.CreateDeclRef(var), expr));
+    stmts.push_back(
+        dec_ctx.ast.CreateAssign(dec_ctx.ast.CreateDeclRef(var), expr));
   }
 }
 
@@ -1275,7 +1300,7 @@ void IRToASTVisitor::VisitFunctionDecl(llvm::Function &func) {
   auto tudecl{dec_ctx.ast_ctx.getTranslationUnitDecl()};
   ExprGen expr_gen{dec_ctx};
   auto type{expr_gen.GetQualType(GetFixedFunctionType(func))};
-  decl = ast.CreateFunctionDecl(tudecl, type, name);
+  decl = dec_ctx.ast.CreateFunctionDecl(tudecl, type, name);
 
   tudecl->addDecl(decl);
 
@@ -1311,7 +1336,7 @@ void IRToASTVisitor::VisitFunctionDecl(llvm::Function &func) {
       // (`varname_addr` being a common name used by clang for variables used as
       // storage for parameters e.g. a parameter named "foo" has a corresponding
       // local variable named "foo_addr").
-      var = ast.CreateVarDecl(
+      var = dec_ctx.ast.CreateVarDecl(
           fdecl, expr_gen.GetQualType(alloca->getAllocatedType()), name);
       fdecl->addDecl(var);
     } else if (inst.hasNUsesOrMore(2) ||
@@ -1335,7 +1360,7 @@ void IRToASTVisitor::VisitFunctionDecl(llvm::Function &func) {
           type = dec_ctx.ast_ctx.getPointerType(arrayType->getElementType());
         }
 
-        var = ast.CreateVarDecl(fdecl, type, name);
+        var = dec_ctx.ast.CreateVarDecl(fdecl, type, name);
         fdecl->addDecl(var);
 
         if (auto phi = llvm::dyn_cast<llvm::PHINode>(&inst)) {
@@ -1363,14 +1388,14 @@ void IRToASTVisitor::VisitFunctionDecl(llvm::Function &func) {
                   std::to_string(GetNumDecls<clang::FunctionDecl>(tudecl))};
         auto ftype{iasm->getFunctionType()};
         auto type{expr_gen.GetQualType(ftype)};
-        decl = ast.CreateFunctionDecl(tudecl, type, name);
+        decl = dec_ctx.ast.CreateFunctionDecl(tudecl, type, name);
 
         std::vector<clang::ParmVarDecl *> iasm_params;
         for (auto arg : ftype->params()) {
           auto arg_type{expr_gen.GetQualType(arg)};
           auto name{"arg_" + std::to_string(iasm_params.size())};
-          iasm_params.push_back(
-              ast.CreateParamDecl(decl->getDeclContext(), arg_type, name));
+          iasm_params.push_back(dec_ctx.ast.CreateParamDecl(
+              decl->getDeclContext(), arg_type, name));
         }
 
         auto fdecl{decl->getAsFunction()};

--- a/lib/AST/TypeProvider.cpp
+++ b/lib/AST/TypeProvider.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-present, Trail of Bits, Inc.
+ * Copyright (c) 2022-present, Trail of Bits, Inc.
  * All rights reserved.
  *
  * This source code is licensed in accordance with the terms specified in

--- a/lib/AST/TypeProvider.cpp
+++ b/lib/AST/TypeProvider.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2021-present, Trail of Bits, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed in accordance with the terms specified in
+ * the LICENSE file found in the root directory of this source tree.
+ */
+
+#include "rellic/AST/TypeProvider.h"
+
+#include "rellic/AST/Util.h"
+
+namespace rellic {
+TypeProvider::TypeProvider(DecompilationContext& dec_ctx) : dec_ctx(dec_ctx) {}
+TypeProvider::~TypeProvider() = default;
+
+clang::QualType TypeProvider::GetFunctionReturnType(llvm::Function&) {
+  return {};
+}
+
+clang::QualType TypeProvider::GetArgumentType(llvm::Argument&) { return {}; }
+
+clang::QualType TypeProvider::GetGlobalVarType(llvm::GlobalVariable&) {
+  return {};
+}
+
+// Defers to DecompilationContext::GetQualType
+class FallbackTypeProvider : public TypeProvider {
+ public:
+  FallbackTypeProvider(DecompilationContext& dec_ctx);
+  clang::QualType GetFunctionReturnType(llvm::Function& func) override;
+  clang::QualType GetArgumentType(llvm::Argument& arg) override;
+  clang::QualType GetGlobalVarType(llvm::GlobalVariable& gvar) override;
+};
+
+FallbackTypeProvider::FallbackTypeProvider(DecompilationContext& dec_ctx)
+    : TypeProvider(dec_ctx) {}
+
+clang::QualType FallbackTypeProvider::GetFunctionReturnType(
+    llvm::Function& func) {
+  return dec_ctx.GetQualType(func.getReturnType());
+}
+
+clang::QualType FallbackTypeProvider::GetArgumentType(llvm::Argument& arg) {
+  return dec_ctx.GetQualType(arg.getType());
+}
+
+clang::QualType FallbackTypeProvider::GetGlobalVarType(
+    llvm::GlobalVariable& gvar) {
+  return dec_ctx.GetQualType(gvar.getValueType());
+}
+
+// Fixes function arguments that have a byval attribute
+class ByValFixupTypeProvider : public TypeProvider {
+ public:
+  ByValFixupTypeProvider(DecompilationContext& dec_ctx);
+
+  // This function fixes types for those arguments that are passed by value
+  // using the `byval` attribute. They need special treatment because those
+  // arguments, instead of actually being passed by value, are instead passed
+  // "by reference" from a bitcode point of view, with the caveat that the
+  // actual semantics are more like "create a copy of the reference before
+  // calling, and pass a pointer to that copy instead" (this is done
+  // implicitly). Thus, we need to convert a function type like
+  //
+  //   `i32 @do_foo(%struct.foo* byval(%struct.foo) align 4 %f)`
+  //
+  // into
+  //
+  //   `i32 @do_foo(%struct.foo %f)`
+  clang::QualType GetArgumentType(llvm::Argument& arg) override;
+};
+
+ByValFixupTypeProvider::ByValFixupTypeProvider(DecompilationContext& dec_ctx)
+    : TypeProvider(dec_ctx) {}
+
+clang::QualType ByValFixupTypeProvider::GetArgumentType(llvm::Argument& arg) {
+  if (!arg.hasByValAttr()) {
+    return {};
+  }
+
+  auto byval{arg.getAttribute(llvm::Attribute::ByVal)};
+  return dec_ctx.GetQualType(byval.getValueAsType());
+}
+
+TypeProviderCombiner::TypeProviderCombiner(DecompilationContext& dec_ctx)
+    : TypeProvider(dec_ctx) {
+  AddProvider<FallbackTypeProvider>();
+  AddProvider<ByValFixupTypeProvider>();
+}
+
+void TypeProviderCombiner::AddProvider(std::unique_ptr<TypeProvider> provider) {
+  providers.push_back(std::move(provider));
+}
+
+clang::QualType TypeProviderCombiner::GetFunctionReturnType(
+    llvm::Function& func) {
+  for (auto it{providers.rbegin()}; it != providers.rend(); ++it) {
+    auto& provider{*it};
+    auto res{provider->GetFunctionReturnType(func)};
+    if (!res.isNull()) {
+      return res;
+    }
+  }
+  return {};
+}
+
+clang::QualType TypeProviderCombiner::GetArgumentType(llvm::Argument& arg) {
+  for (auto it{providers.rbegin()}; it != providers.rend(); ++it) {
+    auto& provider{*it};
+    auto res{provider->GetArgumentType(arg)};
+    if (!res.isNull()) {
+      return res;
+    }
+  }
+  return {};
+}
+
+clang::QualType TypeProviderCombiner::GetGlobalVarType(
+    llvm::GlobalVariable& gvar) {
+  for (auto it{providers.rbegin()}; it != providers.rend(); ++it) {
+    auto& provider{*it};
+    auto res{provider->GetGlobalVarType(gvar)};
+    if (!res.isNull()) {
+      return res;
+    }
+  }
+  return {};
+}
+}  // namespace rellic

--- a/lib/AST/Util.cpp
+++ b/lib/AST/Util.cpp
@@ -434,7 +434,11 @@ clang::QualType DecompilationContext::GetQualType(llvm::Type *type) {
     case llvm::Type::IntegerTyID: {
       auto size{type->getIntegerBitWidth()};
       CHECK(size > 0) << "Integer bit width has to be greater than 0";
-      result = ast.GetLeastIntTypeForBitWidth(size, /*sign=*/0);
+      if (size == 8) {
+        result = ast_ctx.CharTy;
+      } else {
+        result = ast.GetLeastIntTypeForBitWidth(size, /*sign=*/0);
+      }
     } break;
 
     case llvm::Type::FunctionTyID: {

--- a/lib/AST/Util.cpp
+++ b/lib/AST/Util.cpp
@@ -19,6 +19,7 @@
 #include <numeric>
 
 #include "rellic/AST/ASTBuilder.h"
+#include "rellic/BC/Util.h"
 #include "rellic/Exception.h"
 
 namespace rellic {
@@ -397,5 +398,126 @@ unsigned DecompilationContext::InsertZExpr(const z3::expr &e) {
   auto idx{z3_exprs.size()};
   z3_exprs.push_back(e);
   return idx;
+}
+
+clang::QualType DecompilationContext::GetQualType(llvm::Type *type) {
+  DLOG(INFO) << "GetQualType: " << LLVMThingToString(type);
+
+  clang::QualType result;
+  switch (type->getTypeID()) {
+    case llvm::Type::VoidTyID:
+      result = ast_ctx.VoidTy;
+      break;
+
+    case llvm::Type::HalfTyID:
+      result = ast_ctx.HalfTy;
+      break;
+
+    case llvm::Type::FloatTyID:
+      result = ast_ctx.FloatTy;
+      break;
+
+    case llvm::Type::DoubleTyID:
+      result = ast_ctx.DoubleTy;
+      break;
+
+    case llvm::Type::X86_FP80TyID:
+      result = ast_ctx.LongDoubleTy;
+      break;
+
+    case llvm::Type::FP128TyID:
+      result = ast_ctx.Float128Ty;
+      break;
+
+    case llvm::Type::IntegerTyID: {
+      auto size{type->getIntegerBitWidth()};
+      CHECK(size > 0) << "Integer bit width has to be greater than 0";
+      result = ast.GetLeastIntTypeForBitWidth(size, /*sign=*/0);
+    } break;
+
+    case llvm::Type::FunctionTyID: {
+      auto func{llvm::cast<llvm::FunctionType>(type)};
+      auto ret{GetQualType(func->getReturnType())};
+      std::vector<clang::QualType> params;
+      for (auto param : func->params()) {
+        params.push_back(GetQualType(param));
+      }
+      auto epi{clang::FunctionProtoType::ExtProtoInfo()};
+      epi.Variadic = func->isVarArg();
+      result = ast_ctx.getFunctionType(ret, params, epi);
+    } break;
+
+    case llvm::Type::PointerTyID: {
+      auto ptr_type{llvm::cast<llvm::PointerType>(type)};
+      if (ptr_type->isOpaque()) {
+        result = ast_ctx.VoidPtrTy;
+      } else {
+        result = ast_ctx.getPointerType(
+            GetQualType(ptr_type->getNonOpaquePointerElementType()));
+      }
+    } break;
+
+    case llvm::Type::ArrayTyID: {
+      auto arr{llvm::cast<llvm::ArrayType>(type)};
+      auto elm{GetQualType(arr->getElementType())};
+      result = ast_ctx.getConstantArrayType(
+          elm, llvm::APInt(64, arr->getNumElements()), nullptr,
+          clang::ArrayType::ArraySizeModifier::Normal, 0);
+    } break;
+
+    case llvm::Type::StructTyID: {
+      clang::RecordDecl *sdecl{nullptr};
+      auto &decl{type_decls[type]};
+      if (!decl) {
+        auto tudecl{ast_ctx.getTranslationUnitDecl()};
+        auto strct{llvm::cast<llvm::StructType>(type)};
+        auto sname{strct->isLiteral() ? ("literal_struct_" +
+                                         std::to_string(num_literal_structs++))
+                                      : strct->getName().str()};
+        if (sname.empty()) {
+          sname = "struct" + std::to_string(num_declared_structs++);
+        }
+
+        // Create a C struct declaration
+        decl = sdecl = ast.CreateStructDecl(tudecl, sname);
+
+        // Add fields to the C struct
+        for (auto ecnt{0U}; ecnt < strct->getNumElements(); ++ecnt) {
+          auto etype{GetQualType(strct->getElementType(ecnt))};
+          auto fname{"field" + std::to_string(ecnt)};
+          sdecl->addDecl(ast.CreateFieldDecl(sdecl, etype, fname));
+        }
+
+        // Complete the C struct definition
+        sdecl->completeDefinition();
+        // Add C struct to translation unit
+        tudecl->addDecl(sdecl);
+
+      } else {
+        sdecl = clang::cast<clang::RecordDecl>(decl);
+      }
+      result = ast_ctx.getRecordType(sdecl);
+    } break;
+
+    case llvm::Type::MetadataTyID:
+      result = ast_ctx.VoidPtrTy;
+      break;
+
+    default: {
+      if (type->isVectorTy()) {
+        auto vtype{llvm::cast<llvm::FixedVectorType>(type)};
+        auto etype{GetQualType(vtype->getElementType())};
+        auto ecnt{vtype->getNumElements()};
+        auto vkind{clang::VectorType::GenericVector};
+        result = ast_ctx.getVectorType(etype, ecnt, vkind);
+      } else {
+        THROW() << "Unknown LLVM Type: " << LLVMThingToString(type);
+      }
+    } break;
+  }
+
+  CHECK_THROW(!result.isNull()) << "Unknown LLVM Type";
+
+  return result;
 }
 }  // namespace rellic

--- a/lib/AST/Util.cpp
+++ b/lib/AST/Util.cpp
@@ -19,6 +19,7 @@
 #include <numeric>
 
 #include "rellic/AST/ASTBuilder.h"
+#include "rellic/AST/TypeProvider.h"
 #include "rellic/BC/Util.h"
 #include "rellic/Exception.h"
 
@@ -392,7 +393,8 @@ DecompilationContext::DecompilationContext(clang::ASTUnit &ast_unit)
     : ast_unit(ast_unit),
       ast_ctx(ast_unit.getASTContext()),
       ast(ast_unit),
-      marker_expr(ast.CreateAdd(ast.CreateFalse(), ast.CreateFalse())) {}
+      marker_expr(ast.CreateAdd(ast.CreateFalse(), ast.CreateFalse())),
+      type_provider(std::make_unique<TypeProviderCombiner>(*this)) {}
 
 unsigned DecompilationContext::InsertZExpr(const z3::expr &e) {
   auto idx{z3_exprs.size()};

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -40,6 +40,7 @@ set(AST_HEADERS
   "${include_dir}/AST/StructGenerator.h"
   "${include_dir}/AST/SubprogramGenerator.h"
   "${include_dir}/AST/TransformVisitor.h"
+  "${include_dir}/AST/TypeProvider.h"
   "${include_dir}/AST/Util.h"
   "${include_dir}/AST/Z3CondSimplify.h"
 )
@@ -80,12 +81,12 @@ set(AST_SOURCES
   AST/StructFieldRenamer.cpp
   AST/StructGenerator.cpp
   AST/SubprogramGenerator.cpp
+  AST/TypeProvider.cpp
 )
 
 set(BC_SOURCES
   BC/Util.cpp
 )
-
 
 add_library("${PROJECT_NAME}" STATIC
   ${public_HEADERS}
@@ -94,64 +95,62 @@ add_library("${PROJECT_NAME}" STATIC
 
   Decompiler.cpp
   Exception.cpp
-  
-  "${POST_CONFIGURE_FILE}"  # Version.cpp
-)
 
+  "${POST_CONFIGURE_FILE}" # Version.cpp
+)
 
 set_target_properties(
   "${PROJECT_NAME}" PROPERTIES
-    VISIBILITY_INLINES_HIDDEN YES
-    CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN YES
+  CXX_VISIBILITY_PRESET hidden
 )
 
-#link version information
+# link version information
 target_link_libraries("${PROJECT_NAME}"
   PUBLIC
-    "${PROJECT_NAME}_cxx_settings"
-    glog::glog
-    z3::libz3
-    "${llvm_libs}"
-    clangIndex
-    clangCodeGen
-    clangASTMatchers
-    clangTooling
+  "${PROJECT_NAME}_cxx_settings"
+  glog::glog
+  z3::libz3
+  "${llvm_libs}"
+  clangIndex
+  clangCodeGen
+  clangASTMatchers
+  clangTooling
 )
 
 set_target_properties("${PROJECT_NAME}"
   PROPERTIES
-    LINKER_LANGUAGE
-      CXX
+  LINKER_LANGUAGE
+  CXX
 )
 
 target_include_directories("${PROJECT_NAME}"
   PUBLIC
-    $<BUILD_INTERFACE:${RELLIC_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${RELLIC_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
 
 if(RELLIC_ENABLE_INSTALL)
   include(GNUInstallDirs)
   install(
     DIRECTORY
-      "${include_dir}"
+    "${include_dir}"
     DESTINATION
-      ${CMAKE_INSTALL_INCLUDEDIR})
-  
-  
+    ${CMAKE_INSTALL_INCLUDEDIR})
+
   install(
     TARGETS
-      "${PROJECT_NAME}"
+    "${PROJECT_NAME}"
     EXPORT
-      "${PROJECT_NAME}Targets"
+    "${PROJECT_NAME}Targets"
     RUNTIME
-      DESTINATION
-        ${CMAKE_INSTALL_BINDIR}
+    DESTINATION
+    ${CMAKE_INSTALL_BINDIR}
     LIBRARY
-      DESTINATION
-        ${CMAKE_INSTALL_LIBDIR}
+    DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE
-      DESTINATION
-        ${CMAKE_INSTALL_LIBDIR}
+    DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}
   )
 endif(RELLIC_ENABLE_INSTALL)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -88,6 +88,7 @@ set(BC_SOURCES
   BC/Util.cpp
 )
 
+
 add_library("${PROJECT_NAME}" STATIC
   ${public_HEADERS}
   ${AST_SOURCES}
@@ -95,62 +96,64 @@ add_library("${PROJECT_NAME}" STATIC
 
   Decompiler.cpp
   Exception.cpp
-
-  "${POST_CONFIGURE_FILE}" # Version.cpp
+  
+  "${POST_CONFIGURE_FILE}"  # Version.cpp
 )
+
 
 set_target_properties(
   "${PROJECT_NAME}" PROPERTIES
-  VISIBILITY_INLINES_HIDDEN YES
-  CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN YES
+    CXX_VISIBILITY_PRESET hidden
 )
 
-# link version information
+#link version information
 target_link_libraries("${PROJECT_NAME}"
   PUBLIC
-  "${PROJECT_NAME}_cxx_settings"
-  glog::glog
-  z3::libz3
-  "${llvm_libs}"
-  clangIndex
-  clangCodeGen
-  clangASTMatchers
-  clangTooling
+    "${PROJECT_NAME}_cxx_settings"
+    glog::glog
+    z3::libz3
+    "${llvm_libs}"
+    clangIndex
+    clangCodeGen
+    clangASTMatchers
+    clangTooling
 )
 
 set_target_properties("${PROJECT_NAME}"
   PROPERTIES
-  LINKER_LANGUAGE
-  CXX
+    LINKER_LANGUAGE
+      CXX
 )
 
 target_include_directories("${PROJECT_NAME}"
   PUBLIC
-  $<BUILD_INTERFACE:${RELLIC_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${RELLIC_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
 
 if(RELLIC_ENABLE_INSTALL)
   include(GNUInstallDirs)
   install(
     DIRECTORY
-    "${include_dir}"
+      "${include_dir}"
     DESTINATION
-    ${CMAKE_INSTALL_INCLUDEDIR})
-
+      ${CMAKE_INSTALL_INCLUDEDIR})
+  
+  
   install(
     TARGETS
-    "${PROJECT_NAME}"
+      "${PROJECT_NAME}"
     EXPORT
-    "${PROJECT_NAME}Targets"
+      "${PROJECT_NAME}Targets"
     RUNTIME
-    DESTINATION
-    ${CMAKE_INSTALL_BINDIR}
+      DESTINATION
+        ${CMAKE_INSTALL_BINDIR}
     LIBRARY
-    DESTINATION
-    ${CMAKE_INSTALL_LIBDIR}
+      DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE
-    DESTINATION
-    ${CMAKE_INSTALL_LIBDIR}
+      DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}
   )
 endif(RELLIC_ENABLE_INSTALL)

--- a/lib/Decompiler.cpp
+++ b/lib/Decompiler.cpp
@@ -83,6 +83,11 @@ Result<DecompilationResult, DecompilationError> Decompile(
                                   module->getTargetTriple()};
     auto ast_unit{clang::tooling::buildASTFromCodeWithArgs("", args, "out.c")};
     rellic::DecompilationContext dec_ctx(*ast_unit);
+
+    for (auto& provider : options.additional_providers) {
+      dec_ctx.type_provider->AddProvider(provider->create(dec_ctx));
+    }
+
     rellic::GenerateAST::run(*module, dec_ctx);
     // TODO(surovic): Add llvm::Value* -> clang::Decl* map
     // Especially for llvm::Argument* and llvm::Function*.

--- a/tools/decomp/Decomp.cpp
+++ b/tools/decomp/Decomp.cpp
@@ -124,7 +124,7 @@ int main(int argc, char* argv[]) {
   opts.lower_switches = FLAGS_lower_switch;
   opts.remove_phi_nodes = FLAGS_remove_phi_nodes;
 
-  auto result{rellic::Decompile(std::move(module), opts)};
+  auto result{rellic::Decompile(std::move(module), std::move(opts))};
   if (result.Succeeded()) {
     auto value{result.TakeValue()};
     value.ast->getASTContext().getTranslationUnitDecl()->print(output);


### PR DESCRIPTION
Supersedes #302

Allows mechanisms to override the default LLVM type-to-Clang type conversion for functions and global variables