### PR TITLE
Make built docker image runnable on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ To build the docker image using LLVM 16 for Ubuntu 22.04 on amd64 you can run th
 ARCH=amd64; UBUNTU=22.04; LLVM=16; docker build . \
   -t rellic:llvm${LLVM}-ubuntu${UBUNTU}-${ARCH} \
   -f Dockerfile \
+  --platform linux/${ARCH}
   --build-arg UBUNTU_VERSION=${UBUNTU} \
   --build-arg ARCH=${ARCH} \
   --build-arg LLVM_VERSION=${LLVM}


### PR DESCRIPTION
Without this line the image built just fine, but when trying to run it failed with `qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory` error. I believe this parameter forces it to be build for the selected architecture so it is runnable under other archs.
Pretty sure this wont break building docker in Linux, but I haven't tested it.