### PR TITLE
Add LLVM and CLANG includes to target

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -131,6 +131,8 @@ target_include_directories("${PROJECT_NAME}"
   PUBLIC
     $<BUILD_INTERFACE:${RELLIC_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
+    ${LLVM_INCLUDE_DIRS}
+    ${CLANG_INCLUDE_DIRS}
 )
 
 if(RELLIC_ENABLE_INSTALL)


### PR DESCRIPTION
LLVM and CLANG include dirs should be brought in via target_link_libraries but it would not compile on MacOS for me without these changes making it explicit.